### PR TITLE
chore: check that pr titles follow conventional commit format

### DIFF
--- a/.github/workflows/conventional-commit-pr-title.yml
+++ b/.github/workflows/conventional-commit-pr-title.yml
@@ -1,4 +1,4 @@
-name: Convential Commit
+name: Conventional Commit
 # Validates PR title follows conventional commits
 
 on:


### PR DESCRIPTION
## Reason for Change
- This is in preparation for automating change logs and releases

## Changes

- add GHA to lint PR titles using conventional commit format.
