### PR TITLE
feat: include license file with python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /api/python/src/cellxgene_ontology_guide.egg-info/SOURCES.txt
 /api/python/src/cellxgene_ontology_guide.egg-info/top_level.txt
 /api/python/src/cellxgene_ontology_guide.egg-info/
+!/api/python/LICENSE

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -1,7 +1,7 @@
-install:
-	pip install -e .
+install: package-data
+	pip install .
 
-install-dev:
+install-dev: package-data
 	pip install -e .[test]
 
 package-data:

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -4,8 +4,13 @@ install:
 install-dev:
 	pip install -e .[test]
 
+package-data:
+	cp ../../LICENSE ./LICENSE
+
 clean:
 	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info
+	rm ./LICENSE
+
 
 unit-tests:
 	python -m pytest tests

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Access ontology data used by CZ cellxgene"
 authors = [
     { name = "Chan Zuckerberg Initiative Foundation", email = "cellxgene@chanzuckerberg.com" }
 ]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = "~= 3.11"
 dependencies = []


### PR DESCRIPTION
## Reason for Change

- the lincense file needs to be included for legal reason.

## Changes

- add license to python package
- add packaging recipes to make file and run them when installing.

## Testing steps

- ran make install and check the build and egg-info has the expect license.
- ran make cleanup and check the license file was cleaned up.

