### PR TITLE
feat: Support getting download link for ontology from source repo

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/artifact_download.py
+++ b/api/python/src/cellxgene_ontology_guide/artifact_download.py
@@ -16,7 +16,7 @@ def load_artifact_by_schema(schema_version: str, filename: str) -> Any:
 
     :param schema_version: str version of the schema to load ontology assets for
     :param filename: str name of the asset to load
-    :return: bytes content of the asset
+    :return: Nested dict representation of the content of the asset
     """
     try:
         ontology_asset_tag = SCHEMA_VERSION_TO_ONTOLOGY_ASSET_TAG[schema_version]

--- a/api/python/src/cellxgene_ontology_guide/artifact_download.py
+++ b/api/python/src/cellxgene_ontology_guide/artifact_download.py
@@ -1,10 +1,14 @@
+import gzip
+import json
+from io import BytesIO
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 from constants import ONTOLOGY_ASSET_RELEASE_URL, SCHEMA_VERSION_TO_ONTOLOGY_ASSET_TAG
 
 
-def load_artifact_by_schema(schema_version: str, filename: str) -> bytes:
+def load_artifact_by_schema(schema_version: str, filename: str) -> Any:
     """
     Load ontology files from GitHub Release Assets, based on the provided schema version.
     Returns ValueError if the schema version is not supported in this package version or filename is not found for
@@ -25,7 +29,11 @@ def load_artifact_by_schema(schema_version: str, filename: str) -> bytes:
         with urlopen(download_url) as response:
             if response.status == 200:
                 content: bytes = response.read()
-                return content
+                if filename.endswith("json.gz"):
+                    with gzip.open(BytesIO(content), "rt") as f:
+                        return json.load(f)
+                else:
+                    return json.loads(content)
             else:
                 raise ValueError(f"Server responded with status code: {response.status}")
     except HTTPError as e:

--- a/api/python/src/cellxgene_ontology_guide/entities.py
+++ b/api/python/src/cellxgene_ontology_guide/entities.py
@@ -1,0 +1,48 @@
+from enum import Enum
+
+
+class OntologyGuideEnum(Enum):
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_
+
+
+class Ontology(OntologyGuideEnum):
+    """
+    Enum for the set of ontologies supported by CZ CellXGene.
+    """
+
+    CL = "CL"
+    EFO = "EFO"
+    MONDO = "MONDO"
+    UBERON = "UBERON"
+    HANCESTRO = "HANCESTRO"
+    HSAPDV = "HsapDv"
+    MMUSDV = "MmusDv"
+    PATO = "PATO"
+    NCBITAXON = "NCBITaxon"
+
+
+class OntologyVariant(OntologyGuideEnum):
+    """
+    Enum for the standard set of ontology variants. Each is curated for a specific purpose.
+
+    See https://oboacademy.github.io/obook/explanation/owl-format-variants/ for more information on the distinction
+    and use-cases for each variant.
+    """
+
+    FULL = "full"
+    BASE = "base"
+    SIMPLE = "simple"
+    BASIC = "basic"
+
+
+class OntologyFileType(OntologyGuideEnum):
+    """
+    Enum for the standard set of ontology file types. Each requires different parsing tools, but relay the same
+    information.
+    """
+
+    OWL = "owl"
+    OBO = "obo"
+    JSON = "json"

--- a/api/python/src/cellxgene_ontology_guide/entities.py
+++ b/api/python/src/cellxgene_ontology_guide/entities.py
@@ -1,29 +1,23 @@
 from enum import Enum
 
 
-class OntologyGuideEnum(Enum):
-    @classmethod
-    def has_value(cls, value):
-        return value in cls._value2member_map_
-
-
-class Ontology(OntologyGuideEnum):
+class Ontology(Enum):
     """
     Enum for the set of ontologies supported by CZ CellXGene.
     """
 
-    CL = "CL"
-    EFO = "EFO"
-    MONDO = "MONDO"
-    UBERON = "UBERON"
-    HANCESTRO = "HANCESTRO"
-    HSAPDV = "HsapDv"
-    MMUSDV = "MmusDv"
-    PATO = "PATO"
-    NCBITAXON = "NCBITaxon"
+    CL = "cl"
+    EFO = "efo"
+    MONDO = "mondo"
+    UBERON = "uberon"
+    HANCESTRO = "hancestro"
+    HsapDv = "hsapdv"
+    MmusDv = "mmusdv"
+    PATO = "pato"
+    NCBITaxon = "ncbitaxon"
 
 
-class OntologyVariant(OntologyGuideEnum):
+class OntologyVariant(Enum):
     """
     Enum for the standard set of ontology variants. Each is curated for a specific purpose.
 
@@ -37,7 +31,7 @@ class OntologyVariant(OntologyGuideEnum):
     BASIC = "basic"
 
 
-class OntologyFileType(OntologyGuideEnum):
+class OntologyFileType(Enum):
     """
     Enum for the standard set of ontology file types. Each requires different parsing tools, but relay the same
     information.

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -163,7 +163,7 @@ class OntologyParser:
         return label
 
     def get_ontology_download_url(
-        self, ontology_name: Ontology, ontology_filetype: OntologyFileType, ontology_variant: OntologyVariant = None
+        self, ontology: Ontology, ontology_filetype: OntologyFileType, ontology_variant: OntologyVariant = None
     ) -> str:
         """
         Get the download URL for a given ontology file. If the ontology_variant is not provided, the default ontology
@@ -173,22 +173,15 @@ class OntologyParser:
         get_ontology_download_url("CL", "owl") -> "http://example.com/2024-01-01/cl.owl"
         get_ontology_download_url("CL", "obo", "base") -> "http://example.com/2024-01-01/cl-base.obo"
 
-        :param ontology_name: str name of the ontology to fetch
+        :param ontology: Ontology enum of the ontology to fetch
         :param ontology_filetype: OntologyFileType enum of the ontology file type to fetch
         :param ontology_variant: OntologyVariant enum of the ontology variant to fetch
         :return: str download URL for the requested ontology file
         """
-        if not Ontology.has_value(ontology_name):
-            raise ValueError(f"Ontology {ontology_name} is not supported by cellxgene-ontology-guide.")
-        if not OntologyFileType.has_value(ontology_filetype):
-            raise ValueError(f"Ontology filetype {ontology_filetype} is not supported by cellxgene-ontology-guide.")
-        if ontology_variant is not None and not OntologyVariant.has_value(ontology_variant):
-            raise ValueError(f"Ontology variant {ontology_variant} is not supported by cellxgene-ontology-guide.")
-
-        source_url = self.supported_ontologies[ontology_name]["source"]
-        version = self.supported_ontologies[ontology_name]["version"]
+        source_url = self.supported_ontologies[ontology.name]["source"]
+        version = self.supported_ontologies[ontology.name]["version"]
         return (
-            f"{source_url}/{version}/{ontology_name}-{ontology_variant}.{ontology_filetype}"
+            f"{source_url}/{version}/{ontology.value}-{ontology_variant.value}.{ontology_filetype.value}"
             if ontology_variant
-            else f"{source_url}/{version}/{ontology_name}.{ontology_filetype}"
+            else f"{source_url}/{version}/{ontology.value}.{ontology_filetype.value}"
         )

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from cellxgene_ontology_guide.constants import ALL_ONTOLOGY_FILENAME, ONTOLOGY_INFO_FILENAME
+from cellxgene_ontology_guide.entities import Ontology, OntologyFileType, OntologyVariant
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 
 
@@ -127,20 +128,11 @@ def test_get_term_label(ontology_parser):
 
 
 def test_get_ontology_download_url(ontology_parser):
-    assert ontology_parser.get_ontology_download_url("CL", "owl") == "http://example.com/2024-01-01/CL.owl"
-    assert ontology_parser.get_ontology_download_url("CL", "obo", "base") == "http://example.com/2024-01-01/CL-base.obo"
-
-
-def test_get_ontology_download_url__unsupported_filetype(ontology_parser):
-    with pytest.raises(ValueError):
-        ontology_parser.get_ontology_download_url("CL", "yaml")
-
-
-def test_get_ontology_download_url__unsupported_file_variant(ontology_parser):
-    with pytest.raises(ValueError):
-        ontology_parser.get_ontology_download_url("CL", "json", "editable")
-
-
-def test_get_ontology_download_url__unsupported_ontology(ontology_parser):
-    with pytest.raises(ValueError):
-        ontology_parser.get_ontology_download_url("GO", "owl")
+    assert (
+        ontology_parser.get_ontology_download_url(Ontology.CL, OntologyFileType.OWL)
+        == "http://example.com/2024-01-01/cl.owl"
+    )
+    assert (
+        ontology_parser.get_ontology_download_url(Ontology.CL, OntologyFileType.OBO, OntologyVariant.BASE)
+        == "http://example.com/2024-01-01/cl-base.obo"
+    )


### PR DESCRIPTION
## Reason for Change

- #22

## Changes

- clean up / refactor OntologyParser class and load_artifact_by_schema function
- remove multi-ton implementation (deemed overengineering + potential for memory leaks upon further review)
- add function to OntologyParser to construct download links for ontologies from their source repo
- added enums to limit inputs only to construct URLs for known ontology/file variants/file types


## Testing steps

- unit tests

## Notes for Reviewer
- further changes around how we fetch + package the data the OntologyParser reads from will be addressed in separate PRs
