### PR TITLE
feat: add data to the python package 

### DIFF
--- a/api/python/MANIFEST.in
+++ b/api/python/MANIFEST.in
@@ -1,0 +1,2 @@
+include src/cellxgene-ontology-guide/*
+

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -11,7 +11,7 @@ clean: uninstall
 	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info ./src/cellxgene_ontology_guide/data ./LICENSE
 
 package-data:
-  	cp ../../LICENSE ./LICENSE
+	cp ../../LICENSE ./LICENSE
 	cp -r ../../ontology-assets/ ./src/cellxgene_ontology_guide/data
 	touch ./src/cellxgene_ontology_guide/data/__init__.py
 

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -8,8 +8,7 @@ uninstall:
 	pip uninstall -y cellxgene-ontology-guide
 
 clean: uninstall
-	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info ./src/cellxgene_ontology_guide/data
-  	rm ./LICENSE
+	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info ./src/cellxgene_ontology_guide/data ./LICENSE
 
 package-data:
   	cp ../../LICENSE ./LICENSE

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -9,10 +9,10 @@ uninstall:
 
 clean: uninstall
 	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info ./src/cellxgene_ontology_guide/data
-  rm ./LICENSE
+  	rm ./LICENSE
 
 package-data:
-  cp ../../LICENSE ./LICENSE
+  	cp ../../LICENSE ./LICENSE
 	cp -r ../../ontology-assets/ ./src/cellxgene_ontology_guide/data
 	touch ./src/cellxgene_ontology_guide/data/__init__.py
 

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -1,11 +1,19 @@
-install:
-	pip install -e .
+install: package-data
+	pip install .
 
-install-dev:
+install-dev: package-data
 	pip install -e .[test]
 
-clean:
-	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info
+uninstall:
+	pip uninstall -y cellxgene-ontology-guide
+
+clean: uninstall
+	rm -rf ./build ./src/cellxgene_ontology_guide.egg-info ./src/cellxgene_ontology_guide/data
+
+
+package-data:
+	cp -r ../../ontology-assets/ ./src/cellxgene_ontology_guide/data
+	touch ./src/cellxgene_ontology_guide/data/__init__.py
 
 unit-tests:
 	python -m pytest tests

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -19,13 +19,16 @@ test = ["pytest"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["cellxgene_ontology_guide"]
 
-[tool.pytest.ini_options]
-pythonpath = ["src/cellxgene_ontology_guide"]
+[tool.setuptools.package-data]
+"*" = ["*.json", "*.json.gz"]
 
 [tool.setuptools_scm]
 version_file = "src/cellxgene_ontology_guide/_version.py"
 version_scheme = "python-simplified-semver"
 root = "../.."  # relative to the location of the pyproject.toml file
 tag_regex = "^python-api-(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+
+[tool.pytest.ini_options]
+pythonpath = ["src/cellxgene_ontology_guide"]
+

--- a/api/python/src/cellxgene_ontology_guide/constants.py
+++ b/api/python/src/cellxgene_ontology_guide/constants.py
@@ -1,6 +1,7 @@
 import os
 
 PACKAGE_ROOT = os.path.dirname(os.path.realpath(__file__))
+DATA_ROOT = os.path.join(PACKAGE_ROOT, "data")
 ALL_ONTOLOGY_FILENAME = "all_ontology.json.gz"
 ONTOLOGY_INFO_FILENAME = "ontology_info.json"
 ONTOLOGY_ASSET_RELEASE_URL = "https://github.com/chanzuckerberg/cellxgene-ontology-guide/releases/download"


### PR DESCRIPTION
## Reason for Change

- This is to make tracking the supported version easier per release of the cellxgene-ontology-guide python api

## Changes

- packaging the ontology-assets with the python library under cellxgene-ontology-guide/data

## Testing steps

- make install the API and verified the files exist
- make clean the API and verified the files were removed.

## Notes for Reviewer
