### PR TITLE
chore: clean-up ontology_parser single fetch and bulk fetch methods + account for acceptable non-ontology terms

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/constants.py
+++ b/api/python/src/cellxgene_ontology_guide/constants.py
@@ -4,3 +4,4 @@ PACKAGE_ROOT = os.path.dirname(os.path.realpath(__file__))
 DATA_ROOT = os.path.join(PACKAGE_ROOT, "data")
 ONTOLOGY_FILENAME_SUFFIX = ".json.gz"
 ONTOLOGY_INFO_FILENAME = "ontology_info.json"
+VALID_NON_ONTOLOGY_TERMS = ["unknown", "na"]

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any, Dict, Iterable, List, Union
 
+from cellxgene_ontology_guide.constants import VALID_NON_ONTOLOGY_TERMS
 from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_ontology_guide.supported_versions import CXGSchema
 
@@ -49,28 +50,13 @@ class OntologyParser:
         :param include_self: boolean flag to include the term itself as an ancestor
         :return: flattened List[str] of ancestor terms
         """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return []
         ontology_name = self._parse_ontology_name(term_id)
         ancestors = list(self.cxg_schema.ontology(ontology_name)[term_id]["ancestors"].keys())
         return ancestors + [term_id] if include_self else ancestors
 
-    def get_term_ancestors_with_distances(self, term_id: str, include_self: bool = False) -> Dict[str, int]:
-        """
-        Get the ancestor ontology terms for a given term, and their distance from the term_id. If include_self is True,
-        the term itself will be included as an ancestor.
-
-         Example: get_term_ancestors_with_distances("CL:0000005") -> {"CL:0000000": 1, ...}
-
-        :param term_id: str ontology term to find ancestors for
-        :param include_self: boolean flag to include the term itself as an ancestor
-        :return: Dict[str, int] map of ancestor terms and their respective distances from the term_id
-        """
-        ontology_name = self._parse_ontology_name(term_id)
-        ancestors: Dict[str, int] = self.cxg_schema.ontology(ontology_name)[term_id]["ancestors"]
-        if include_self:
-            ancestors[term_id] = 0
-        return ancestors
-
-    def get_term_list_ancestors(self, term_ids: List[str], include_self: bool = False) -> Dict[str, List[str]]:
+    def map_term_ancestors(self, term_ids: Iterable[str], include_self: bool = False) -> Dict[str, List[str]]:
         """
         Get the ancestor ontology terms for each term in a list. If include_self is True, the term itself will be
         included as an ancestor.
@@ -87,27 +73,43 @@ class OntologyParser:
         """
         return {term_id: self.get_term_ancestors(term_id, include_self) for term_id in term_ids}
 
-    def map_high_level_terms(self, term_ids: List[str], high_level_terms: List[str]) -> Dict[str, List[str]]:
+    def get_term_ancestors_with_distances(self, term_id: str, include_self: bool = False) -> Dict[str, int]:
         """
-        Given a list of ontology term IDs and a list of high_level_terms to map them to, returns a dictionary with
-        format
+        Get the ancestor ontology terms for a given term, and their distance from the term_id. If include_self is True,
+        the term itself will be included as an ancestor.
 
-        {"CL:0000003": ["CL:0000000", ...], "CL:0000005": ["CL:0000000", ...]}
+         Example: get_term_ancestors_with_distances("CL:0000005") -> {"CL:0000000": 1, ...}
 
-        Where each term_id is mapped to a List[str] of high-level terms that it is a descendant of. Includes self
-        as a descendant.
-
-        :param term_ids: list of str ontology terms to map high level terms for
-        :param high_level_terms: list of str ontology terms that can be mapped to descendant term_ids
-        :return: Dictionary mapping str term IDs to their respective List[str] of ancestor terms from the input list.
-        Each key maps to empty list if there are no ancestors among the provided input.
+        :param term_id: str ontology term to find ancestors for
+        :param include_self: boolean flag to include the term itself as an ancestor
+        :return: Dict[str, int] map of ancestor terms and their respective distances from the term_id
         """
-        ancestors = self.get_term_list_ancestors(term_ids, include_self=True)
-        for term_id in term_ids:
-            ancestors[term_id] = [
-                high_level_term for high_level_term in ancestors[term_id] if high_level_term in high_level_terms
-            ]
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return {}
+        ontology_name = self._parse_ontology_name(term_id)
+        ancestors: Dict[str, int] = self.cxg_schema.ontology(ontology_name)[term_id]["ancestors"]
+        if include_self:
+            ancestors[term_id] = 0
         return ancestors
+
+    def map_term_ancestors_with_distances(
+        self, term_ids: Iterable[str], include_self: bool = False
+    ) -> Dict[str, Dict[str, int]]:
+        """
+        Get the ancestor ontology terms for each term in a list, and their distance from the term_id. If include_self is
+        True, the term itself will be included as an ancestor.
+
+         Example: get_term_list_ancestors_with_distances(["CL:0000003", "CL:0000005"], include_self=True) -> {
+            "CL:0000003": {"CL:0000003": 0, ...},
+            "CL:0000005": {"CL:0000005": 0, "CL:0000000": 1, ...}
+        }
+
+        :param term_ids: list of str ontology terms to find ancestors for
+        :param include_self: boolean flag to include the term itself as an ancestor
+        :return: Dictionary mapping str term IDs to their respective Dict[str, int] map of ancestor terms and their
+        respective distances from the term_id
+        """
+        return {term_id: self.get_term_ancestors_with_distances(term_id, include_self) for term_id in term_ids}
 
     def get_distance_between_terms(self, term_id_1: str, term_id_2: str) -> int:
         """
@@ -153,6 +155,57 @@ class OntologyParser:
             if ancestors_1[ancestor] + ancestors_2[ancestor] == min_sum_distances
         ]
 
+    def get_high_level_terms(self, term_id: str, high_level_terms: List[str]) -> List[str]:
+        """
+        Get the high-level ontology terms for a given term. High-level terms are defined as the ancestors of the term
+        that are part of the high-level ontology terms supported by cellxgene-ontology-guide.
+
+        Example: get_high_level_terms("CL:0000005") -> ["CL:0000000", ...]
+
+        :param term_id: str ontology term to find high-level terms for
+        :param high_level_terms: list of str ontology terms to check for ancestry to term_id
+        :return: List[str] of high-level terms that the term is a descendant of
+        """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return []
+        ancestors = self.get_term_ancestors(term_id, include_self=True)
+        return [high_level_term for high_level_term in ancestors if high_level_term in high_level_terms]
+
+    def map_high_level_terms(self, term_ids: List[str], high_level_terms: List[str]) -> Dict[str, List[str]]:
+        """
+        Given a list of ontology term IDs and a list of high_level_terms to map them to, returns a dictionary with
+        format
+
+        {"CL:0000003": ["CL:0000000", ...], "CL:0000005": ["CL:0000000", ...]}
+
+        Where each term_id is mapped to a List[str] of high-level terms that it is a descendant of. Includes self
+        as a descendant.
+
+        :param term_ids: list of str ontology terms to map high level terms for
+        :param high_level_terms: list of str ontology terms to be mapped to descendant term_ids
+        :return: Dictionary mapping str term IDs to their respective List[str] of ancestor terms from the input list.
+        Each key maps to empty list if there are no ancestors among the provided input.
+        """
+        return {term_id: self.get_high_level_terms(term_id, high_level_terms) for term_id in term_ids}
+
+    def get_highest_level_term(self, term_id: str, high_level_terms: List[str]) -> Union[str, None]:
+        """
+        Get the highest level ontology term for a given term. The highest level term is defined as the ancestor of the
+        term that is part of the high-level ontology terms supported by cellxgene-ontology-guide.
+
+        Example: get_highest_level_term("CL:0000005") -> "CL:0000000"
+
+        :param term_id: str ontology term to find highest level term for
+        :param high_level_terms: list of str ontology terms to check for ancestry to term_id
+        :return: str highest level term that the term is a descendant of, or None if it is not a descendant of any
+        high-level terms
+        """
+        high_level_terms = self.get_high_level_terms(term_id, high_level_terms)
+        term_ancestors_and_distances = self.get_term_ancestors_with_distances(term_id, include_self=True)
+        if not high_level_terms:
+            return None
+        return max(high_level_terms, key=lambda high_level_term: term_ancestors_and_distances[high_level_term])
+
     def map_highest_level_term(self, term_ids: List[str], high_level_terms: List[str]) -> Dict[str, Union[str, None]]:
         """
         Given a list of ontology term IDs and a list of high_level_terms to map them to, returns a dictionary with
@@ -160,30 +213,39 @@ class OntologyParser:
 
         {"CL:0000003": "CL:0000000", "CL:0000005": "CL:0000000"}
 
-        Where each term_id is mapped to the highest level term that it is a descendant of, from the list provided. Includes
-        term itself as a descendant. Maps to None if term_id does not map to any high level terms among the provided input.
+        Where each term_id is mapped to the highest level term that it is a descendant of, from the list provided.
+        Includes term itself as a descendant. Maps to None if term_id does not map to any high level terms among the
+        provided input.
 
         :param term_ids: list of str ontology terms to map high level terms for
         :param high_level_terms: list of str ontology terms that can be mapped to descendant term_ids
         :return: Dictionary mapping str term IDs to their respective List[str] of ancestor terms from the input list.
         Each key maps to empty list if there are no ancestors among the provided input.
         """
-        high_level_term_map = self.map_high_level_terms(term_ids, high_level_terms)
-        highest_level_term_map = dict()
-        for term_id in term_ids:
-            term_ancestors_and_distances = self.get_term_ancestors_with_distances(term_id, include_self=True)
-            # map term_id to the high_level_term with the longest distance from term_id
-            highest_level_term_map[term_id] = (
-                max(
-                    high_level_term_map[term_id],
-                    key=lambda high_level_term: term_ancestors_and_distances[high_level_term],
-                )
-                if high_level_term_map[term_id]
-                else None
-            )
-        return highest_level_term_map
+        return {term_id: self.get_highest_level_term(term_id, high_level_terms) for term_id in term_ids}
 
-    def get_terms_descendants(self, term_ids: Iterable[str], include_self: bool = False) -> Dict[str, List[str]]:
+    def get_term_descendants(self, term_id: str, include_self: bool = False) -> List[str]:
+        """
+        Get the descendant ontology terms for a given term. If include_self is True, the term itself will be included as
+        a descendant.
+
+        Example: get_term_descendant("CL:0000005") -> ["CL:0000005", "CL:0002363", ...]
+
+        :param term_id: str ontology term to find descendants for
+        :param include_self: boolean flag to include the term itself as a descendant
+        :return: List[str] of descendant terms
+        """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return []
+        ontology_name = self._parse_ontology_name(term_id)
+        descendants = [term_id] if include_self else []
+        for candidate_descendant, candidate_metadata in self.cxg_schema.ontology(ontology_name).items():
+            ancestors = candidate_metadata["ancestors"].keys()
+            if term_id in ancestors:
+                descendants.append(candidate_descendant)
+        return descendants
+
+    def map_term_descendants(self, term_ids: Iterable[str], include_self: bool = False) -> Dict[str, List[str]]:
         """
         Get the descendant ontology terms for each term in a list. If include_self is True, the term itself will be
          included as a descendant.
@@ -198,9 +260,12 @@ class OntologyParser:
         :return: Dictionary mapping str term IDs to their respective flattened List[str] of descendant terms. Maps to
         empty list if there are no descendants.
         """
-        descendants_dict = dict()
+        descendants_dict: Dict[str, List[str]] = dict()
         ontology_names = set()
         for term_id in term_ids:
+            if term_id in VALID_NON_ONTOLOGY_TERMS:
+                descendants_dict[term_id] = []
+                continue
             ontology_name = self._parse_ontology_name(term_id)
             descendants_dict[term_id] = [term_id] if include_self else []
             ontology_names.add(ontology_name)
@@ -223,6 +288,8 @@ class OntologyParser:
         :param term_id: str ontology term to check for deprecation
         :return: boolean flag indicating whether the term is deprecated
         """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return False
         ontology_name = self._parse_ontology_name(term_id)
         is_deprecated: bool = self.cxg_schema.ontology(ontology_name)[term_id].get("deprecated")
         return is_deprecated
@@ -236,6 +303,8 @@ class OntologyParser:
         :param term_id: str ontology term to check a replacement term for
         :return: replacement str term ID if it exists, None otherwise
         """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return None
         ontology_name = self._parse_ontology_name(term_id)
         replaced_by: str = self.cxg_schema.ontology(ontology_name)[term_id].get("replaced_by")
         return replaced_by if replaced_by else None
@@ -255,6 +324,8 @@ class OntologyParser:
         :param term_id: str ontology term to fetch metadata for
         :return: Dict with keys 'Comments', 'Term Tracker', and 'Consider' containing associated metadata.
         """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return {"comments": None, "term_tracker": None, "consider": None}
         ontology_name = self._parse_ontology_name(term_id)
         return {
             key: self.cxg_schema.ontology(ontology_name)[term_id].get(key, None)
@@ -270,9 +341,22 @@ class OntologyParser:
         :param term_id: str ontology term to fetch label for
         :return: str human-readable label for the term
         """
+        if term_id in VALID_NON_ONTOLOGY_TERMS:
+            return term_id
         ontology_name = self._parse_ontology_name(term_id)
         label: str = self.cxg_schema.ontology(ontology_name)[term_id]["label"]
         return label
+
+    def map_term_labels(self, term_ids: Iterable[str]) -> Dict[str, str]:
+        """
+        Fetch the human-readable label for a given list of ontology terms.
+
+        Example: map_term_label(["CL:0000005", "CL:0000003"]) -> {"CL:0000005": "fibroblast neural crest derived", "CL:0000003": "fibroblast"}
+
+        :param term_ids: list of str ontology terms to fetch label for
+        :return: Dict[str, str] mapping term IDs to their respective human-readable labels
+        """
+        return {term_id: self.get_term_label(term_id) for term_id in term_ids}
 
     def get_ontology_download_url(self, ontology: Ontology) -> str:
         """

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -116,7 +116,9 @@ def map_term_ancestors_with_distances(ontology_parser):
         "CL:0000000": {},
         "CL:0000004": {"CL:0000000": 2, "CL:0000001": 1, "CL:0000002": 1},
     }
-    assert ontology_parser.map_term_ancestors_with_distances(["CL:0000000", "CL:0000004", "unknown"], include_self=True) == {
+    assert ontology_parser.map_term_ancestors_with_distances(
+        ["CL:0000000", "CL:0000004", "unknown"], include_self=True
+    ) == {
         "CL:0000000": {"CL:0000000": 0},
         "CL:0000004": {"CL:0000000": 2, "CL:0000001": 1, "CL:0000002": 1, "CL:0000004": 0},
         "unknown": {},

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -81,6 +81,19 @@ def test_get_term_ancestors(ontology_parser):
         "CL:0000002",
         "CL:0000004",
     ]
+    assert ontology_parser.get_term_ancestors("unknown", include_self=True) == []
+
+
+def test_map_term_ancestors(ontology_parser):
+    assert ontology_parser.map_term_ancestors(["CL:0000000", "CL:0000004"]) == {
+        "CL:0000000": [],
+        "CL:0000004": ["CL:0000000", "CL:0000001", "CL:0000002"],
+    }
+    assert ontology_parser.map_term_ancestors(["CL:0000000", "CL:0000004", "unknown"], include_self=True) == {
+        "CL:0000000": ["CL:0000000"],
+        "CL:0000004": ["CL:0000000", "CL:0000001", "CL:0000002", "CL:0000004"],
+        "unknown": [],
+    }
 
 
 def test_get_term_ancestors_with_distances(ontology_parser):
@@ -95,21 +108,38 @@ def test_get_term_ancestors_with_distances(ontology_parser):
         "CL:0000002": 1,
         "CL:0000004": 0,
     }
+    assert ontology_parser.get_term_ancestors_with_distances("unknown", include_self=True) == {}
 
 
-def test_get_term_list_ancestors(ontology_parser):
-    assert ontology_parser.get_term_list_ancestors(["CL:0000000", "CL:0000004"]) == {
-        "CL:0000000": [],
-        "CL:0000004": ["CL:0000000", "CL:0000001", "CL:0000002"],
+def map_term_ancestors_with_distances(ontology_parser):
+    assert ontology_parser.map_term_ancestors_with_distances(["CL:0000000", "CL:0000004"]) == {
+        "CL:0000000": {},
+        "CL:0000004": {"CL:0000000": 2, "CL:0000001": 1, "CL:0000002": 1},
     }
-    assert ontology_parser.get_term_list_ancestors(["CL:0000000", "CL:0000004"], include_self=True) == {
-        "CL:0000000": ["CL:0000000"],
-        "CL:0000004": ["CL:0000000", "CL:0000001", "CL:0000002", "CL:0000004"],
+    assert ontology_parser.map_term_ancestors_with_distances(["CL:0000000", "CL:0000004", "unknown"], include_self=True) == {
+        "CL:0000000": {"CL:0000000": 0},
+        "CL:0000004": {"CL:0000000": 2, "CL:0000001": 1, "CL:0000002": 1, "CL:0000004": 0},
+        "unknown": {},
     }
 
 
-def test_get_terms_descendants(ontology_parser):
-    assert ontology_parser.get_terms_descendants(["CL:0000000", "CL:0000004"]) == {
+def test_get_term_descendants(ontology_parser):
+    assert ontology_parser.get_term_descendants("CL:0000000") == [
+        "CL:0000001",
+        "CL:0000002",
+        "CL:0000003",
+        "CL:0000004",
+        "CL:0000005",
+        "CL:0000006",
+        "CL:0000007",
+    ]
+    assert ontology_parser.get_term_descendants("CL:0000004") == []
+    assert ontology_parser.get_term_descendants("CL:0000004", include_self=True) == ["CL:0000004"]
+    assert ontology_parser.get_term_descendants("na") == []
+
+
+def test_map_term_descendants(ontology_parser):
+    assert ontology_parser.map_term_descendants(["CL:0000000", "CL:0000004"]) == {
         "CL:0000000": [
             "CL:0000001",
             "CL:0000002",
@@ -121,7 +151,7 @@ def test_get_terms_descendants(ontology_parser):
         ],
         "CL:0000004": [],
     }
-    assert ontology_parser.get_terms_descendants(["CL:0000000", "CL:0000004"], include_self=True) == {
+    assert ontology_parser.map_term_descendants(["CL:0000000", "CL:0000004", "unknown"], include_self=True) == {
         "CL:0000000": [
             "CL:0000000",
             "CL:0000001",
@@ -133,6 +163,7 @@ def test_get_terms_descendants(ontology_parser):
             "CL:0000007",
         ],
         "CL:0000004": ["CL:0000004"],
+        "unknown": [],
     }
 
 
@@ -163,11 +194,36 @@ def test_get_term_label(ontology_parser):
     assert ontology_parser.get_term_label("CL:0000004") == "cell BC"
 
 
+def test_map_term_labels(ontology_parser):
+    assert ontology_parser.map_term_labels(["CL:0000000", "CL:0000004", "unknown", "na"]) == {
+        "CL:0000000": "cell A",
+        "CL:0000004": "cell BC",
+        "unknown": "unknown",
+        "na": "na",
+    }
+
+
+def test_get_high_level_terms(ontology_parser):
+    high_level_terms = ["CL:0000000", "CL:0000001"]
+    assert ontology_parser.get_high_level_terms("CL:0000004", high_level_terms) == ["CL:0000000", "CL:0000001"]
+    assert ontology_parser.get_high_level_terms("CL:0000008", high_level_terms) == []
+    assert ontology_parser.get_high_level_terms("CL:0000000", high_level_terms) == ["CL:0000000"]
+    assert ontology_parser.get_high_level_terms("na", high_level_terms) == []
+
+
 def test_map_high_level_terms(ontology_parser):
     assert ontology_parser.map_high_level_terms(
-        term_ids=["CL:0000000", "CL:0000008", "CL:0000004"],
+        term_ids=["CL:0000000", "CL:0000008", "CL:0000004", "unknown"],
         high_level_terms=["CL:0000000", "CL:0000001"],
-    ) == {"CL:0000000": ["CL:0000000"], "CL:0000008": [], "CL:0000004": ["CL:0000000", "CL:0000001"]}
+    ) == {"CL:0000000": ["CL:0000000"], "CL:0000008": [], "CL:0000004": ["CL:0000000", "CL:0000001"], "unknown": []}
+
+
+def test_get_highest_level_term(ontology_parser):
+    high_level_terms = ["CL:0000000", "CL:0000001"]
+    assert ontology_parser.get_highest_level_term("CL:0000004", high_level_terms) == "CL:0000000"
+    assert ontology_parser.get_highest_level_term("CL:0000000", high_level_terms) == "CL:0000000"
+    assert ontology_parser.get_highest_level_term("CL:0000008", high_level_terms) is None
+    assert ontology_parser.get_highest_level_term("na", high_level_terms) is None
 
 
 def test_map_highest_level_term(ontology_parser):


### PR DESCRIPTION
## Changes

- support "unknown" and "na" term_ids, which are non-ontology BUT are valid substitutes according to the CxG schema. Note that we may need to version this behavior, should it change in the future (i.e. acceptable non-ontology term added, removed)
- rename all bulk fetch methods --> "map_<subject>" 
- rename all single fetch methods --> "get_<subject>"
- added single fetch methods for high level terms, highest level terms, term descendants
- added bulk fetch method for ancestors_with_distances and term labels
- reordered ontology_parser to follow more logical method declarations (but this is causing the diff to look larger than it is, so I can revert if its confusing to review...)
