### PR TITLE
feat: add is_valid_term_id method to OntologyParser

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -41,7 +41,8 @@ class OntologyParser:
 
     def is_valid_term_id(self, term_id: str) -> bool:
         """
-        Check if an ontology term ID is valid and defined in a supported ontology
+        Check if an ontology term ID is valid and defined in a supported ontology. If deprecated but defined
+        in the ontology, it is considered valid.
 
         :param term_id: str ontology term to check
         :return: boolean flag indicating whether the term is supported

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -39,6 +39,21 @@ class OntologyParser:
 
         return ontology_name
 
+    def is_valid_term_id(self, term_id: str) -> bool:
+        """
+        Check if an ontology term ID is valid and defined in a supported ontology
+
+        :param term_id: str ontology term to check
+        :return: boolean flag indicating whether the term is supported
+        """
+        try:
+            ontology_name = self._parse_ontology_name(term_id)
+            if term_id in self.cxg_schema.ontology(ontology_name):
+                return True
+        except ValueError:
+            return False
+        return False
+
     def get_term_ancestors(self, term_id: str, include_self: bool = False) -> List[str]:
         """
         Get the ancestor ontology terms for a given term. If include_self is True, the term itself will be included as

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -73,11 +73,11 @@ def test_parse_ontology_name__not_supported(ontology_parser):
         ontology_parser._parse_ontology_name("GO:0000001")
 
 
-def test_is_valid_term_id(ontology_parser):
-    assert ontology_parser.is_valid_term_id("CL:0000001")
-    assert ontology_parser.is_valid_term_id("CL:0000003")  # test deprecated term is valid
-    assert not ontology_parser.is_valid_term_id("CL:0000009")
-    assert not ontology_parser.is_valid_term_id("GO:0000001")
+@pytest.mark.parametrize(
+    "term_id,expected", [("CL:0000001", True), ("CL:0000003", True), ("CL:0000009", False), ("GO:0000001", False)]
+)
+def test_is_valid_term_id(ontology_parser, term_id, expected):
+    assert ontology_parser.is_valid_term_id(term_id) == expected
 
 
 def test_get_term_ancestors(ontology_parser):

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -75,6 +75,7 @@ def test_parse_ontology_name__not_supported(ontology_parser):
 
 def test_is_valid_term_id(ontology_parser):
     assert ontology_parser.is_valid_term_id("CL:0000001")
+    assert ontology_parser.is_valid_term_id("CL:0000003")   # test deprecated term is valid
     assert not ontology_parser.is_valid_term_id("CL:0000009")
     assert not ontology_parser.is_valid_term_id("GO:0000001")
 

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -73,6 +73,12 @@ def test_parse_ontology_name__not_supported(ontology_parser):
         ontology_parser._parse_ontology_name("GO:0000001")
 
 
+def test_is_valid_term_id(ontology_parser):
+    assert ontology_parser.is_valid_term_id("CL:0000001")
+    assert not ontology_parser.is_valid_term_id("CL:0000009")
+    assert not ontology_parser.is_valid_term_id("GO:0000001")
+
+
 def test_get_term_ancestors(ontology_parser):
     assert ontology_parser.get_term_ancestors("CL:0000004") == ["CL:0000000", "CL:0000001", "CL:0000002"]
     assert ontology_parser.get_term_ancestors("CL:0000004", include_self=True) == [

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -75,7 +75,7 @@ def test_parse_ontology_name__not_supported(ontology_parser):
 
 def test_is_valid_term_id(ontology_parser):
     assert ontology_parser.is_valid_term_id("CL:0000001")
-    assert ontology_parser.is_valid_term_id("CL:0000003")   # test deprecated term is valid
+    assert ontology_parser.is_valid_term_id("CL:0000003")  # test deprecated term is valid
     assert not ontology_parser.is_valid_term_id("CL:0000009")
     assert not ontology_parser.is_valid_term_id("GO:0000001")
 


### PR DESCRIPTION
## Reason for Change

- helper function utilized in cellxgene-schema validator 
## Changes

- add is_valid_term_id method, returns bool determining if a term_id is from a valid ontology and is defined in the given schema version's corresponding ontology. If deprecated but defined in the ontology, it IS a valid term.