### PR TITLE
fix: Do not include organoid term_id as a descendant of term_id

### DIFF
--- a/tools/ontology-builder/src/descendent_mapping_generator.py
+++ b/tools/ontology-builder/src/descendent_mapping_generator.py
@@ -184,10 +184,6 @@ def build_descendants_by_term_id(
                 if descendant in organoids_by_ontology_term_id:
                     descendant_accept_list.append(organoids_by_ontology_term_id[descendant])
 
-            # Add organoid term_id, if any.
-            if term_id in organoids_by_ontology_term_id:
-                descendant_accept_list.append(organoids_by_ontology_term_id[term_id])
-
             if not descendant_accept_list:
                 continue
 

--- a/tools/ontology-builder/tests/test_descendant_mapping_generator.py
+++ b/tools/ontology-builder/tests/test_descendant_mapping_generator.py
@@ -112,7 +112,7 @@ def test_refine_descendants_by_term_id(hierarchy, mock_ontology_parser, expected
     [
         ([["a:0"], ["a:3 (organoid)"]], {"a:0": ["a:3 (organoid)"]}),
         ([["a:0"], ["a:3", "a:3 (organoid)"]], {"a:0": ["a:3", "a:3 (organoid)"]}),
-        ([["a:0 (organoid)"], ["a:0"]], {"a:0": ["a:0 (organoid)"]}),
+        ([["a:0 (organoid)"], []], {}),
     ],
 )
 def test_refine_descendants_by_term_id_organoid(hierarchy, mock_ontology_parser, expected):


### PR DESCRIPTION
## Reason for Change

Do not include organoid term_id as a descendant of term_id. Example:
```  
"UBERON:0001987": [
    "UBERON:0000453",
    "UBERON:0001987 (organoid)",
    "UBERON:0002450"
  ]
```
should be
```  
"UBERON:0001987": [
    "UBERON:0000453",
    "UBERON:0002450"
  ]
```

## Changes

- modify descendant mapping logic to not include organoid self as an ontology term_id

## Testing steps

- updated tests

## Notes for Reviewer
