### PR TITLE
chore: use trusted publisher to publish pypi package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - main
 
+  pull_request:
+    branches:
+      - "*"
+
 permissions:
   contents: write
   pull-requests: write
@@ -18,7 +22,7 @@ jobs:
         with:
           manifest-file: ".release-please-manifest.json"
           config-file: "release-please-config.json"
-          target-branch: "main"
+          target-branch: "tsmith/pypi"
     outputs:
       ontology_assets_upload_url: ${{ steps.release.outputs.ontology-assets--upload_url }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -61,21 +65,27 @@ jobs:
   publish-pypi-package:
     runs-on: [ubuntu-latest]
     needs: release-please
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cellxgene-ontology-guide
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     if: contains(needs.release-please.outputs.paths_released, 'api/python')
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: tsmith/pypi
           fetch-depth: 0
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - name: build and publish
-        # TODO change to make publish
+      - name: build
         run: |
-          make test/publish -C api/python
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN_BENTO007 }}
+          make build
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: api/python/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           python-version: 3.11
       - name: build
         run: |
-          make build
+          make build -C api/python
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,6 @@ on:
     branches:
       - main
 
-  pull_request:
-    branches:
-      - "*"
-
 permissions:
   contents: write
   pull-requests: write
@@ -22,7 +18,7 @@ jobs:
         with:
           manifest-file: ".release-please-manifest.json"
           config-file: "release-please-config.json"
-          target-branch: "tsmith/pypi"
+          target-branch: "main"
     outputs:
       ontology_assets_upload_url: ${{ steps.release.outputs.ontology-assets--upload_url }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -75,7 +71,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: tsmith/pypi
+          ref: main
           fetch-depth: 0
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -87,5 +83,4 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           packages-dir: api/python/dist

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -20,10 +20,11 @@ build: package-data
 	pip install build twine
 	python -m build
 
-test/publish: build
+release/testpypi: build
 	python -m twine upload --repository testpypi dist/*
 
-publish: build
+release/pypi: build
+	# Manually release in case CI/CD pipeline is not working in ./.github/workflows/release.yml
 	python -m twine upload dist/*
 
 unit-tests:


### PR DESCRIPTION
## Reason for Change

- release to pypi form GHA

## Changes

- modify release.yml to release to pypi
- use [trust release](https://docs.pypi.org/trusted-publishers/) instead of personal access token.
- added comments to api/python/makefile to suggested users only publish using the make if CICD is not working.

## Testing steps

- Generated a release, and publish to test pypi.


