### PR TITLE
chore: enable code coverage

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -51,7 +51,8 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Ontology builder unit tests
         run: |
-          cd tools/ontology-builder && make unit-tests
+          cd tools/ontology-builder 
+          make coverage/run
       - name: Upload coverage results as an artifact
         uses: actions/upload-artifact@v3
         with:
@@ -84,7 +85,7 @@ jobs:
       - name: Python API unit tests
         run: |
           cd api/python
-          make unit-tests
+          make coverage/run
       - name: Upload coverage results as an artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -99,9 +99,15 @@ jobs:
       - unit-test-python-api
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: install coverage
+        run: pip install coverage
       - uses: actions/download-artifact@v3
         with:
           name: coverage

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/tools/ontology-builder/.coverage*
+          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/.coverage*
           retention-days: 3
 
   unit-test-python-api:
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/api/python/.coverage*
+          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/.coverage*
           retention-days: 3
 
   submit-codecoverage:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Ontology builder unit tests
         run: |
           cd tools/ontology-builder && make unit-tests
+      - name: Upload coverage results as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/tools/ontology-builder/.coverage*
+          retention-days: 3
 
   unit-test-python-api:
     runs-on: ubuntu-latest
@@ -79,3 +85,34 @@ jobs:
         run: |
           cd api/python
           make unit-tests
+      - name: Upload coverage results as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/api/python/.coverage*
+          retention-days: 3
+
+  submit-codecoverage:
+    needs:
+      - unit-test-ontology-builder
+      - unit-test-python-api
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: .
+      - name: coverage report
+        run: |
+          make coverage/report-xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,PYTHON
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 /api/python/LICENSE
 /api/python/src/cellxgene_ontology_guide/data/
 /api/python/dist/
-.coverage
+.coverage*
 /htmlcov/
 /api/python/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /api/python/LICENSE
 /api/python/src/cellxgene_ontology_guide/data/
 /api/python/dist/
+.coverage
+/htmlcov/
+/api/python/docs/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+include tools/coverage.mk
+
 lint:
 	pre-commit run --all-files

--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -1,3 +1,5 @@
+include ../../tools/coverage.mk
+
 install: package-data
 	pip install .
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = "~= 3.10"
 dependencies = ["semantic_version>=2.10.0,<3"]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "coverage"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -30,3 +30,4 @@ root = "../.."  # relative to the location of the pyproject.toml file
 
 [tool.pytest.ini_options]
 pythonpath = ["src/cellxgene_ontology_guide"]
+

--- a/tools/coverage.mk
+++ b/tools/coverage.mk
@@ -1,0 +1,17 @@
+# shared coverage targets
+
+COVERAGE_DATA_FILE=.coverage.$(shell git rev-parse --short HEAD)
+export COVERAGE_RUN_ARGS:=--data-file=$(COVERAGE_DATA_FILE) --branch --parallel-mode
+
+
+coverage/run:
+	coverage run $(COVERAGE_RUN_ARGS) -m pytest ./tests;
+
+coverage/combine:
+	coverage combine --data-file=$(COVERAGE_DATA_FILE)
+
+coverage/report-xml: coverage/combine
+	coverage xml --data-file=$(COVERAGE_DATA_FILE) -i --skip-empty
+
+coverage/report-html: coverage/combine
+	coverage html --data-file=$(COVERAGE_DATA_FILE) -i --skip-empty

--- a/tools/coverage.mk
+++ b/tools/coverage.mk
@@ -1,7 +1,7 @@
 # shared coverage targets
-
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
 COVERAGE_DATA_FILE=.coverage.$(shell git rev-parse --short HEAD)
-export COVERAGE_RUN_ARGS:=--data-file=$(COVERAGE_DATA_FILE) --branch --parallel-mode
+export COVERAGE_RUN_ARGS:=--data-file=$(REPO_ROOT)/$(COVERAGE_DATA_FILE) --branch --parallel-mode
 
 
 coverage/run:

--- a/tools/ontology-builder/Makefile
+++ b/tools/ontology-builder/Makefile
@@ -1,3 +1,5 @@
+include ../coverage.mk
+
 unit-tests:
 	python -m pytest tests
 

--- a/tools/ontology-builder/requirements-dev.txt
+++ b/tools/ontology-builder/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+coverage


### PR DESCRIPTION
## Reason for Change
enable code coverage to help maintain a high coding standard

# Changes
- enable code coverage to the python api and ontology-builder
- combine the coverage reports and submit to codecoverage.
- setup a GHA run to run codecoverge for prs and main

