### PR TITLE
fix: move get_ontology_download_url.

### DIFF
--- a/api/python/notebooks/Python API.ipynb
+++ b/api/python/notebooks/Python API.ipynb
@@ -2,35 +2,35 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "id": "c689e76c-0a81-45b9-a0af-3d8450fae525",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.136706Z",
-     "start_time": "2024-03-25T21:40:23.133667Z"
+     "end_time": "2024-03-26T22:16:48.360024Z",
+     "start_time": "2024-03-26T22:16:48.357285Z"
     }
    },
    "outputs": [],
    "source": [
     "from cellxgene_ontology_guide.entities import Ontology\n",
     "from cellxgene_ontology_guide.ontology_parser import OntologyParser\n",
-    "from cellxgene_ontology_guide.supported_versions import load_supported_versions"
+    "from cellxgene_ontology_guide.supported_versions import CXGSchema, load_supported_versions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "id": "71f124ef-3769-4000-a929-f3826e5ba2b9",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.155233Z",
-     "start_time": "2024-03-25T21:40:23.151402Z"
+     "end_time": "2024-03-26T22:16:48.364616Z",
+     "start_time": "2024-03-26T22:16:48.361291Z"
     }
    },
    "outputs": [
@@ -38,7 +38,7 @@
      "data": {
       "text/plain": "{'v5.0.0': {'CL': {'version': 'v2024-01-04',\n   'source': 'https://github.com/obophenotype/cell-ontology/releases/download',\n   'filename': 'cl.owl'},\n  'EFO': {'version': 'v3.62.0',\n   'source': 'https://github.com/EBISPOT/efo/releases/download',\n   'filename': 'efo.owl'},\n  'HANCESTRO': {'version': '3.0',\n   'source': 'https://github.com/EBISPOT/hancestro/raw',\n   'filename': 'hancestro.owl'},\n  'HsapDv': {'version': '11',\n   'source': 'http://aber-owl.net/media/ontologies/HSAPDV',\n   'filename': 'hsapdv.owl'},\n  'MONDO': {'version': 'v2024-01-03',\n   'source': 'https://github.com/monarch-initiative/mondo/releases/download',\n   'filename': 'mondo.owl'},\n  'MmusDv': {'version': '9',\n   'source': 'http://aber-owl.net/media/ontologies/MMUSDV',\n   'filename': 'mmusdv.owl'},\n  'NCBITaxon': {'version': 'v2023-06-20',\n   'source': 'https://github.com/obophenotype/ncbitaxon/releases/download',\n   'filename': 'ncbitaxon.owl.gz'},\n  'UBERON': {'version': 'v2024-01-18',\n   'source': 'https://github.com/obophenotype/uberon/releases/download',\n   'filename': 'uberon.owl'},\n  'PATO': {'version': 'v2023-05-18',\n   'source': 'https://github.com/pato-ontology/pato/raw',\n   'filename': 'pato.owl'}}}"
      },
-     "execution_count": 18,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -50,89 +50,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "id": "54c6f4aa-417a-4b49-bd38-27b95d9de085",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.188473Z",
-     "start_time": "2024-03-25T21:40:23.186020Z"
+     "end_time": "2024-03-26T22:16:48.367739Z",
+     "start_time": "2024-03-26T22:16:48.365697Z"
     }
    },
    "outputs": [],
    "source": [
-    "# Init object to parse information from ontologies associated with a given CellXGene schema_version\n",
-    "ontology_parser = OntologyParser(schema_version=\"v5.0.0\")"
+    "# Init a CXGSchema object to track what ontology versions are supported\n",
+    "cxg_schema = CXGSchema(version=\"v5.0.0\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "7b523f59-7be7-4ac2-aed9-4b651144e9cb",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.198406Z",
-     "start_time": "2024-03-25T21:40:23.195710Z"
-    }
-   },
    "outputs": [
     {
      "data": {
       "text/plain": "'https://github.com/obophenotype/cell-ontology/releases/download/v2024-01-04/cl.owl'"
      },
-     "execution_count": 20,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Build download URL for an ontology file associated with this schema_version\n",
-    "ontology_parser.get_ontology_download_url(Ontology.CL)"
-   ]
+    "cxg_schema.get_ontology_download_url(Ontology.CL)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-26T22:16:48.372508Z",
+     "start_time": "2024-03-26T22:16:48.369460Z"
+    }
+   },
+   "id": "456a647488b474c2",
+   "execution_count": 10
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "c906bbc7-6494-4cbb-9281-d84b6a3852dd",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.201961Z",
-     "start_time": "2024-03-25T21:40:23.199729Z"
-    }
-   },
    "outputs": [
     {
      "data": {
       "text/plain": "'https://github.com/obophenotype/uberon/releases/download/v2024-01-18/uberon.owl'"
      },
-     "execution_count": 21,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ontology_parser.get_ontology_download_url(Ontology.UBERON)"
-   ]
+    "cxg_schema.get_ontology_download_url(Ontology.UBERON)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-26T22:16:48.376121Z",
+     "start_time": "2024-03-26T22:16:48.373430Z"
+    }
+   },
+   "id": "c906bbc7-6494-4cbb-9281-d84b6a3852dd",
+   "execution_count": 11
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "outputs": [],
+   "source": [
+    "# Init object to parse information from ontologies associated with a given CellXGene schema_version\n",
+    "ontology_parser = OntologyParser(schema_version=\"v5.0.0\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-26T22:16:48.379966Z",
+     "start_time": "2024-03-26T22:16:48.377734Z"
+    }
+   },
+   "id": "1a1f25c25664cd11",
+   "execution_count": 12
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "ae3af1ee-a8ac-4095-a914-47f8b0fcb0b7",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.204609Z",
-     "start_time": "2024-03-25T21:40:23.202653Z"
+     "end_time": "2024-03-26T22:16:48.395501Z",
+     "start_time": "2024-03-26T22:16:48.380976Z"
     }
    },
    "outputs": [
@@ -140,7 +153,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['CL:0000586', 'CL:0000039', 'CL:0000000', 'CL:0000021']\n"
+      "['CL:0000586', 'CL:0000039', 'CL:0000000']\n"
      ]
     }
    ],
@@ -152,23 +165,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 14,
    "id": "c582f12c-c5c9-49b0-b275-a47cac257319",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.208443Z",
-     "start_time": "2024-03-25T21:40:23.205987Z"
+     "end_time": "2024-03-26T22:16:48.400402Z",
+     "start_time": "2024-03-26T22:16:48.396933Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "['germ cell', 'germ line cell', 'cell', 'female germ cell']"
+      "text/plain": "['germ cell', 'germ line cell', 'cell']"
      },
-     "execution_count": 23,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -180,23 +193,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 15,
    "id": "261ac136-7340-42c3-bfd5-7df90b4a51fb",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.212573Z",
-     "start_time": "2024-03-25T21:40:23.209258Z"
+     "end_time": "2024-03-26T22:16:48.405286Z",
+     "start_time": "2024-03-26T22:16:48.401302Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "{'CL:0000021': ['CL:0000021',\n  'CL:0000022',\n  'CL:0000023',\n  'CL:0000024',\n  'CL:0000025',\n  'CL:0000675',\n  'CL:0000654',\n  'CL:0000655',\n  'CL:0002090',\n  'CL:0002091',\n  'CL:0002093'],\n 'CL:0000586': ['CL:0000015',\n  'CL:0000016',\n  'CL:0000017',\n  'CL:0000020',\n  'CL:0000018',\n  'CL:0000657',\n  'CL:0000019',\n  'CL:0000408',\n  'CL:0000021',\n  'CL:0000022',\n  'CL:0000023',\n  'CL:0000024',\n  'CL:0000025',\n  'CL:0000675',\n  'CL:0000722',\n  'CL:0000300',\n  'CL:0000654',\n  'CL:0000655',\n  'CL:0000656',\n  'CL:0002090',\n  'CL:0002091',\n  'CL:0002093',\n  'CL:0002290',\n  'CL:0002291',\n  'CL:0011013',\n  'CL:0011014',\n  'CL:0011015',\n  'CL:0011016',\n  'CL:4030036',\n  'CL:4030037']}"
+      "text/plain": "{'CL:0000021': ['CL:0000022',\n  'CL:0000023',\n  'CL:0000024',\n  'CL:0000025',\n  'CL:0000675',\n  'CL:0000654',\n  'CL:0000655',\n  'CL:0002090',\n  'CL:0002091',\n  'CL:0002093'],\n 'CL:0000586': ['CL:0000015',\n  'CL:0000016',\n  'CL:0000017',\n  'CL:0000020',\n  'CL:0000018',\n  'CL:0000657',\n  'CL:0000019',\n  'CL:0000408',\n  'CL:0000021',\n  'CL:0000022',\n  'CL:0000023',\n  'CL:0000024',\n  'CL:0000025',\n  'CL:0000675',\n  'CL:0000722',\n  'CL:0000300',\n  'CL:0000654',\n  'CL:0000655',\n  'CL:0000656',\n  'CL:0002090',\n  'CL:0002091',\n  'CL:0002093',\n  'CL:0002290',\n  'CL:0002291',\n  'CL:0011013',\n  'CL:0011014',\n  'CL:0011015',\n  'CL:0011016',\n  'CL:4030036',\n  'CL:4030037']}"
      },
-     "execution_count": 24,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -208,15 +221,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 16,
    "id": "060844e8-065d-4c86-9271-07e77b1da7dd",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.215539Z",
-     "start_time": "2024-03-25T21:40:23.213292Z"
+     "end_time": "2024-03-26T22:16:48.408764Z",
+     "start_time": "2024-03-26T22:16:48.406269Z"
     }
    },
    "outputs": [
@@ -224,7 +237,7 @@
      "data": {
       "text/plain": "2"
      },
-     "execution_count": 25,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -236,15 +249,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 17,
    "id": "e9fed7c3-5af0-41ce-a6f4-102eadd3e13a",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.218444Z",
-     "start_time": "2024-03-25T21:40:23.216280Z"
+     "end_time": "2024-03-26T22:16:48.412669Z",
+     "start_time": "2024-03-26T22:16:48.410367Z"
     }
    },
    "outputs": [
@@ -252,7 +265,7 @@
      "data": {
       "text/plain": "['CL:0000586']"
      },
-     "execution_count": 26,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -263,15 +276,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 18,
    "id": "a7458db1-0855-4d64-88b3-57850f1c379b",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.222406Z",
-     "start_time": "2024-03-25T21:40:23.220067Z"
+     "end_time": "2024-03-26T22:16:48.415534Z",
+     "start_time": "2024-03-26T22:16:48.413298Z"
     }
    },
    "outputs": [],
@@ -308,15 +321,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 19,
    "id": "5d48933e-abb9-4a6d-9e87-de60e778c318",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.225435Z",
-     "start_time": "2024-03-25T21:40:23.223070Z"
+     "end_time": "2024-03-26T22:16:48.418538Z",
+     "start_time": "2024-03-26T22:16:48.416121Z"
     }
    },
    "outputs": [
@@ -324,7 +337,7 @@
      "data": {
       "text/plain": "{'CL:0000021': ['CL:0000586', 'CL:0000039'],\n 'CL:0000015': ['CL:0000586', 'CL:0000039']}"
      },
-     "execution_count": 28,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -336,15 +349,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 20,
    "id": "d9cfb45a-3a52-4a56-b9b3-b97f93a7bf8e",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.236814Z",
-     "start_time": "2024-03-25T21:40:23.234243Z"
+     "end_time": "2024-03-26T22:16:48.421626Z",
+     "start_time": "2024-03-26T22:16:48.419299Z"
     }
    },
    "outputs": [
@@ -352,7 +365,7 @@
      "data": {
       "text/plain": "{'CL:0000021': 'CL:0000039', 'CL:0000015': 'CL:0000039'}"
      },
-     "execution_count": 29,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -364,15 +377,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 21,
    "id": "d326f228-01b3-4059-b064-ccab51344ad5",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.240005Z",
-     "start_time": "2024-03-25T21:40:23.237746Z"
+     "end_time": "2024-03-26T22:16:48.426703Z",
+     "start_time": "2024-03-26T22:16:48.423022Z"
     }
    },
    "outputs": [
@@ -380,7 +393,7 @@
      "data": {
       "text/plain": "True"
      },
-     "execution_count": 30,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,15 +405,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 22,
    "id": "57fd3be7-633b-4082-9cb8-3cb84edc6236",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.248131Z",
-     "start_time": "2024-03-25T21:40:23.245595Z"
+     "end_time": "2024-03-26T22:16:48.508963Z",
+     "start_time": "2024-03-26T22:16:48.506404Z"
     }
    },
    "outputs": [
@@ -408,7 +421,7 @@
      "data": {
       "text/plain": "'CL:0000000'"
      },
-     "execution_count": 31,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -419,23 +432,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 23,
    "id": "89ffff44-9019-4a95-9a34-68f964c756fe",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2024-03-25T21:40:23.251293Z",
-     "start_time": "2024-03-25T21:40:23.249187Z"
+     "end_time": "2024-03-26T22:16:48.512170Z",
+     "start_time": "2024-03-26T22:16:48.510080Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "{'term_tracker': None,\n 'consider': None,\n 'comments': ['https://github.com/obophenotype/cell-ontology/issues/2124']}"
+      "text/plain": "{'term_tracker': None,\n 'comments': ['https://github.com/obophenotype/cell-ontology/issues/2124'],\n 'consider': None}"
      },
-     "execution_count": 32,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -2,7 +2,6 @@ import re
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 from cellxgene_ontology_guide._constants import VALID_NON_ONTOLOGY_TERMS
-from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_ontology_guide.supported_versions import CXGSchema
 
 
@@ -380,18 +379,3 @@ class OntologyParser:
         :return: Dict[str, str] mapping term IDs to their respective human-readable labels
         """
         return {term_id: self.get_term_label(term_id) for term_id in term_ids}
-
-    def get_ontology_download_url(self, ontology: Ontology) -> str:
-        """
-        Get the download URL for a given ontology file.
-
-        Examples:
-        get_ontology_download_url("CL") -> "http://example.com/2024-01-01/cl.owl"
-
-        :param ontology: Ontology enum of the ontology to fetch
-        :return: str download URL for the requested ontology file
-        """
-        source_url = self.cxg_schema.supported_ontologies[ontology.name]["source"]
-        version = self.cxg_schema.supported_ontologies[ontology.name]["version"]
-        filename = self.cxg_schema.supported_ontologies[ontology.name]["filename"]
-        return f"{source_url}/{version}/{filename}"

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -82,3 +82,18 @@ class CXGSchema:
             file_name = f"{name}-ontology-{onto_version}{ONTOLOGY_FILENAME_SUFFIX}"
             self.ontology_file_names[name] = file_name  # save to file name to access from cache
         return load_ontology_file(self.ontology_file_names[name])
+
+    def get_ontology_download_url(self, ontology: Ontology) -> str:
+        """
+        Get the download URL for a given ontology file.
+
+        Examples:
+        get_ontology_download_url("CL") -> "http://example.com/2024-01-01/cl.owl"
+
+        :param ontology: Ontology enum of the ontology to fetch
+        :return: str download URL for the requested ontology file
+        """
+        source_url = self.supported_ontologies[ontology.name]["source"]
+        version = self.supported_ontologies[ontology.name]["version"]
+        filename = self.supported_ontologies[ontology.name]["filename"]
+        return f"{source_url}/{version}/{filename}"

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 from cellxgene_ontology_guide.supported_versions import CXGSchema
 
@@ -282,7 +281,3 @@ def test_get_distance_between_terms(ontology_parser):
 
     # disjoint distance
     assert ontology_parser.get_distance_between_terms(term_id_1="CL:0000001", term_id_2="CL:0000008") == -1
-
-
-def test_get_ontology_download_url(ontology_parser):
-    assert ontology_parser.get_ontology_download_url(Ontology.CL) == "http://example.com/2024-01-01/cl.owl"

--- a/api/python/tests/test_supported_versions.py
+++ b/api/python/tests/test_supported_versions.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_ontology_guide.supported_versions import (
     CXGSchema,
     get_latest_schema_version,
@@ -15,7 +16,9 @@ MODULE_PATH = "cellxgene_ontology_guide.supported_versions"
 
 @pytest.fixture
 def initialized_CXGSchemaInfo(mock_load_supported_versions):
-    mock_load_supported_versions.return_value = {"v5.0.0": {"CL": {"version": "v2024-01-04"}}}
+    mock_load_supported_versions.return_value = {
+        "v5.0.0": {"CL": {"version": "v2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+    }
     return CXGSchema()
 
 
@@ -100,3 +103,7 @@ class TestCXGSchema:
         ontology_file_contents = {"CL:1234": "efgh"}
         mock_load_ontology_file.return_value = ontology_file_contents
         assert initialized_CXGSchemaInfo.ontology("CL") == {"CL:1234": "efgh"}
+
+
+def test_get_ontology_download_url(initialized_CXGSchemaInfo, mock_load_ontology_file):
+    assert initialized_CXGSchemaInfo.get_ontology_download_url(Ontology.CL) == "http://example.com/v2024-01-01/cl.owl"


### PR DESCRIPTION


## Reason for Change

I think it makes more sense for it to live in supported_versions.py There is no need to initialize an OntologyParser object.

## Changes

- update unit tests
- update notebook

## Testing steps

- verify unit tests pass.

## Notes for Reviewer
