### PR TITLE
chore: fix codecoverage

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload coverage results as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-builder
           path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/.coverage*
           retention-days: 3
 
@@ -89,7 +89,7 @@ jobs:
       - name: Upload coverage results as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-api
           path: /home/runner/work/cellxgene-ontology-guide/cellxgene-ontology-guide/.coverage*
           retention-days: 3
 
@@ -110,7 +110,8 @@ jobs:
         run: pip install coverage
       - uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
+          merge-multiple: true
           path: .
       - name: coverage report
         run: |


### PR DESCRIPTION
Fixing this error cause by updating to actions/upload-artifact@v4 and actions/download-artifact@v4
```
Run actions/upload-artifact@v4
With the provided path, there will be [1](https://github.com/chanzuckerberg/cellxgene-ontology-guide/actions/runs/8455804882/job/23164145371#step:7:1) file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```