### PR TITLE
feat: tag most recently released commit as 'latest'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,18 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: api/python/dist
+
+  tag-latest-release:
+    runs-on: [ubuntu-latest]
+    needs: publish-pypi-package
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Reassign 'latest' tag
+        run: |
+          git tag -f latest
+          git push origin latest
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,4 +104,3 @@ jobs:
         run: |
           git tag -f latest
           git push origin latest
-      


### PR DESCRIPTION
## Reason for Change

- Allow frontend consumers to get the latest release (without needing to make code changes to pin to a specific version), by providing a 'latest' tag that gets reassigned to the HEAD of main whenever a PyPI release occurs. 

## Changes

- update release GHA to add a step to reassign the 'latest' tag immediately following a successful PyPI release