### PR TITLE
chore: deprecate older version of cellxgene schema

### DIFF
--- a/.github/workflows/generate_all_ontology.yml
+++ b/.github/workflows/generate_all_ontology.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           python3 ./tools/ontology-builder/src/all_ontology_generator.py
           git add ./ontology-assets/*.json.gz
+          git add ./ontology-assets/ontology_info.json
       - name: Commit
         run: |
           git commit -m "AUTO: update ontologies"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ This project adheres to the Contributor Covenant [code of conduct](https://githu
 ## Reporting Security Issues
 
 If you believe you have found a security issue, please responsibly disclose by contacting us at [security@chanzuckerberg.com](mailto:security@chanzuckerberg.com).
+
+## Updating to a new Cellxgene Schema Version
+
+1. Update the [ontology_info.json](./ontology-assets/ontology_info.json) file with the new schema version
+2. Leave the older versions in the file for backward compatibility. They will be deprecated and removed automatically after 6 months. That process is handled in [deprecate_previous_cellxgene_schema_versions](https://github.com/chanzuckerberg/cellxgene-ontology/blob/main/tools/ontology-builder/src/all_ontology_generator.py#L311-L311).

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -2,6 +2,8 @@ import functools
 import gzip
 import json
 import os
+import warnings
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from semantic_version import Version
@@ -63,8 +65,16 @@ class CXGSchema:
             raise ValueError(f"Schema version {version} is not supported in this package version.")
 
         self.version = version
-        self.supported_ontologies = ontology_info[version]
+        self.supported_ontologies = ontology_info[version]["ontologies"]
         self.ontology_file_names: Dict[str, str] = {}
+        self.deprecated_on = ontology_info[version].get("deprecated_on")
+        if self.deprecated_on:
+            parsed_date = datetime.strptime(self.deprecated_on, "%Y-%m-%d")
+            warnings.warn(
+                f"Schema version {version} is deprecated as of {parsed_date}. It will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
 
     def ontology(self, name: str) -> Any:
         """Return the ontology terms for the given ontology name. Load from the file cache if available.

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -43,7 +43,9 @@ def ontology_dict():
 @pytest.fixture
 def mock_CXGSchema(ontology_dict, mock_load_supported_versions, mock_load_ontology_file):
     mock_load_supported_versions.return_value = {
-        "v5.0.0": {"CL": {"version": "2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+        "v5.0.0": {
+            "ontologies": {"CL": {"version": "2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+        }
     }
     cxg_schema = CXGSchema()
     cxg_schema.ontology_file_names = {"CL": "CL-ontology-2024-01-01.json.gz"}

--- a/api/python/tests/test_supported_versions.py
+++ b/api/python/tests/test_supported_versions.py
@@ -17,7 +17,9 @@ MODULE_PATH = "cellxgene_ontology_guide.supported_versions"
 @pytest.fixture
 def initialized_CXGSchemaInfo(mock_load_supported_versions):
     mock_load_supported_versions.return_value = {
-        "v5.0.0": {"CL": {"version": "v2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+        "v5.0.0": {
+            "ontologies": {"CL": {"version": "v2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+        }
     }
     return CXGSchema()
 
@@ -71,18 +73,29 @@ def test__load_supported_versions__OK(tmpdir):
 
 class TestCXGSchema:
     def test__init__defaults(self, mock_load_supported_versions):
-        support_versions = {"v5.0.0": "current version", "v0.0.1": "old version"}
+        support_versions = {"v5.0.0": {"ontologies": {}}, "v0.0.1": {"ontologies": {}}}
         mock_load_supported_versions.return_value = support_versions
         cxgs = CXGSchema()
         assert cxgs.version == "v5.0.0"
-        assert cxgs.supported_ontologies == support_versions["v5.0.0"]
+        assert cxgs.supported_ontologies == support_versions["v5.0.0"]["ontologies"]
 
     def test__init__specific_version(self, mock_load_supported_versions):
-        support_versions = {"v5.0.0": "current version", "v0.0.1": "old version"}
+        support_versions = {"v5.0.0": {"ontologies": {}}, "v0.0.1": {"ontologies": {}}}
         mock_load_supported_versions.return_value = support_versions
         cxgs = CXGSchema(version="v0.0.1")
         assert cxgs.version == "v0.0.1"
-        assert cxgs.supported_ontologies == support_versions["v0.0.1"]
+        assert cxgs.supported_ontologies == support_versions["v0.0.1"]["ontologies"]
+
+    def test__init__deprecated_version(self, mock_load_supported_versions):
+        support_versions = {"v5.0.0": {"ontologies": {}}, "v0.0.1": {"ontologies": {}, "deprecated_on": "2024-01-01"}}
+        mock_load_supported_versions.return_value = support_versions
+        # catch the deprecation warning
+        with pytest.warns(DeprecationWarning) as record:
+            CXGSchema(version="v0.0.1")
+        warning = record.pop()
+        assert warning.message.args[0] == (
+            "Schema version v0.0.1 is deprecated as of 2024-01-01 00:00:00. It will be removed in a " "future version."
+        )
 
     def test__init__unsupported_version(self, mock_load_supported_versions):
         mock_load_supported_versions.return_value = {}

--- a/artifact-schemas/ontology_info_schema.json
+++ b/artifact-schemas/ontology_info_schema.json
@@ -8,34 +8,46 @@
       "description": "The version of CellxGene schema that maps to this set of ontology versions",
       "type": "object",
       "properties": {
-        "CL": {
-          "$ref": "#/definitions/ontologyEntry"
+        "deprecated_on": {
+          "type": "string",
+          "description": "The date this version was deprecated. The format of the date is YYYY-MM-DD. If this is the current verison then this field will be empty."
         },
-        "EFO": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "HANCESTRO": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "HsapDv": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "MONDO": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "MmusDv": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "NCBITaxon": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "UBERON": {
-          "$ref": "#/definitions/ontologyEntry"
-        },
-        "PATO": {
-          "$ref": "#/definitions/ontologyEntry"
+        "ontologies": {
+          "type": "object",
+          "properties": {
+            "CL": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "EFO": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "HANCESTRO": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "HsapDv": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "MONDO": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "MmusDv": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "NCBITaxon": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "UBERON": {
+              "$ref": "#/definitions/ontologyEntry"
+            },
+            "PATO": {
+              "$ref": "#/definitions/ontologyEntry"
+            }
+          }
         }
-      }
+      },
+      "required": [
+        "ontologies"
+      ]
     }
   },
   "additionalProperties": false,

--- a/ontology-assets/ontology_info.json
+++ b/ontology-assets/ontology_info.json
@@ -1,49 +1,51 @@
 {
   "v5.0.0": {
-    "CL": {
-      "version": "v2024-01-04",
-      "source": "https://github.com/obophenotype/cell-ontology/releases/download",
-      "filename": "cl.owl"
-    },
-    "EFO": {
-      "version": "v3.62.0",
-      "source": "https://github.com/EBISPOT/efo/releases/download",
-      "filename": "efo.owl"
-    },
-    "HANCESTRO": {
-      "version": "3.0",
-      "source": "https://github.com/EBISPOT/hancestro/raw",
-      "filename": "hancestro.owl"
-    },
-    "HsapDv": {
-      "version": "11",
-      "source": "http://aber-owl.net/media/ontologies/HSAPDV",
-      "filename": "hsapdv.owl"
-    },
-    "MONDO": {
-      "version": "v2024-01-03",
-      "source": "https://github.com/monarch-initiative/mondo/releases/download",
-      "filename": "mondo.owl"
-    },
-    "MmusDv": {
-      "version": "9",
-      "source": "http://aber-owl.net/media/ontologies/MMUSDV",
-      "filename": "mmusdv.owl"
-    },
-    "NCBITaxon": {
-      "version": "v2023-06-20",
-      "source": "https://github.com/obophenotype/ncbitaxon/releases/download",
-      "filename": "ncbitaxon.owl.gz"
-    },
-    "UBERON": {
-      "version": "v2024-01-18",
-      "source": "https://github.com/obophenotype/uberon/releases/download",
-      "filename": "uberon.owl"
-    },
-    "PATO": {
-      "version": "v2023-05-18",
-      "source": "https://github.com/pato-ontology/pato/raw",
-      "filename": "pato.owl"
+    "ontologies": {
+      "CL": {
+        "version": "v2024-01-04",
+        "source": "https://github.com/obophenotype/cell-ontology/releases/download",
+        "filename": "cl.owl"
+      },
+      "EFO": {
+        "version": "v3.62.0",
+        "source": "https://github.com/EBISPOT/efo/releases/download",
+        "filename": "efo.owl"
+      },
+      "HANCESTRO": {
+        "version": "3.0",
+        "source": "https://github.com/EBISPOT/hancestro/raw",
+        "filename": "hancestro.owl"
+      },
+      "HsapDv": {
+        "version": "11",
+        "source": "http://aber-owl.net/media/ontologies/HSAPDV",
+        "filename": "hsapdv.owl"
+      },
+      "MONDO": {
+        "version": "v2024-01-03",
+        "source": "https://github.com/monarch-initiative/mondo/releases/download",
+        "filename": "mondo.owl"
+      },
+      "MmusDv": {
+        "version": "9",
+        "source": "http://aber-owl.net/media/ontologies/MMUSDV",
+        "filename": "mmusdv.owl"
+      },
+      "NCBITaxon": {
+        "version": "v2023-06-20",
+        "source": "https://github.com/obophenotype/ncbitaxon/releases/download",
+        "filename": "ncbitaxon.owl.gz"
+      },
+      "UBERON": {
+        "version": "v2024-01-18",
+        "source": "https://github.com/obophenotype/uberon/releases/download",
+        "filename": "uberon.owl"
+      },
+      "PATO": {
+        "version": "v2023-05-18",
+        "source": "https://github.com/pato-ontology/pato/raw",
+        "filename": "pato.owl"
+      }
     }
   }
 }

--- a/tools/ontology-builder/src/all_ontology_generator.py
+++ b/tools/ontology-builder/src/all_ontology_generator.py
@@ -344,8 +344,9 @@ if __name__ == "__main__":
     ontology_info = get_ontology_info_file()
     current_version = _get_latest_version(ontology_info.keys())
     latest_ontology_version = ontology_info[current_version]
-    _download_ontologies(latest_ontology_version["ontologies"])
-    _parse_ontologies(latest_ontology_version["ontologies"])
+    latest_ontologies = latest_ontology_version["ontologies"]
+    _download_ontologies(latest_ontologies)
+    _parse_ontologies(latest_ontologies)
     deprecate_previous_cellxgene_schema_versions(ontology_info, current_version)
     expired_files = update_ontology_info(ontology_info)
     logging.info("Removing expired files:\n\t", "\t\n".join(expired_files))
@@ -355,6 +356,6 @@ if __name__ == "__main__":
     # validate against the schema
     schema_file = os.path.join(env.SCHEMA_DIR, "all_ontology_schema.json")
     registry = register_schemas()
-    result = [verify_json(schema_file, output_file, registry) for output_file in _parse_ontologies(ontology_info)]
+    result = [verify_json(schema_file, output_file, registry) for output_file in _parse_ontologies(latest_ontologies)]
     if not all(result):
         sys.exit(1)

--- a/tools/ontology-builder/src/all_ontology_generator.py
+++ b/tools/ontology-builder/src/all_ontology_generator.py
@@ -344,8 +344,8 @@ if __name__ == "__main__":
     ontology_info = get_ontology_info_file()
     current_version = _get_latest_version(ontology_info.keys())
     latest_ontology_version = ontology_info[current_version]
-    _download_ontologies(latest_ontology_version)
-    _parse_ontologies(latest_ontology_version)
+    _download_ontologies(latest_ontology_version["ontologies"])
+    _parse_ontologies(latest_ontology_version["ontologies"])
     deprecate_previous_cellxgene_schema_versions(ontology_info, current_version)
     expired_files = update_ontology_info(ontology_info)
     logging.info("Removing expired files:\n\t", "\t\n".join(expired_files))

--- a/tools/ontology-builder/src/all_ontology_generator.py
+++ b/tools/ontology-builder/src/all_ontology_generator.py
@@ -5,8 +5,9 @@ import os
 import re
 import sys
 import urllib.request
+from datetime import datetime, timedelta
 from threading import Thread
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Set
 from urllib.error import HTTPError, URLError
 
 import env
@@ -19,9 +20,7 @@ def _get_latest_version(versions: List[str]) -> str:
     return "v" + str(sorted([semantic_version.Version.coerce(version[1:]) for version in versions])[-1])
 
 
-def _get_ontology_info_file(
-    ontology_info_file: str = env.ONTOLOGY_INFO_FILE, cellxgene_schema_version: Optional[str] = None
-) -> Any:
+def get_ontology_info_file(ontology_info_file: str = env.ONTOLOGY_INFO_FILE) -> Any:
     """
     Read ontology information from file
 
@@ -31,12 +30,20 @@ def _get_ontology_info_file(
     :return ontology information
     """
     with open(ontology_info_file, "r") as f:
-        ontology_info = json.load(f)
-        if cellxgene_schema_version:
-            ontology_info_version = ontology_info[cellxgene_schema_version]
-        else:
-            ontology_info_version = ontology_info[_get_latest_version(ontology_info.keys())]
-        return ontology_info_version
+        return json.load(f)
+
+
+def save_ontology_info(ontology_info: Dict[str, Any], ontology_info_file: str = env.ONTOLOGY_INFO_FILE) -> None:
+    """
+    Save ontology information to file
+
+    :param Dict[str, Any] ontology_info: ontology information to save
+    :param str ontology_info_file: path to file to save ontology information
+
+    :rtype None
+    """
+    with open(ontology_info_file, "w") as f:
+        json.dump(ontology_info, f, indent=2)
 
 
 def _download_ontologies(ontology_info: Dict[str, Any], output_dir: str = env.RAW_ONTOLOGY_DIR) -> None:
@@ -50,7 +57,7 @@ def _download_ontologies(ontology_info: Dict[str, Any], output_dir: str = env.RA
     """
 
     def download(_ontology: str, _url: str) -> None:
-        print(f"Start Downloading {_ontology}")
+        logging.info(f"Start Downloading {_ontology}")
         # Format of ontology (handles cases where they are compressed)
         download_format = _url.split(".")[-1]
 
@@ -61,7 +68,7 @@ def _download_ontologies(ontology_info: Dict[str, Any], output_dir: str = env.RA
             os.remove(output_file + ".gz")
         else:
             urllib.request.urlretrieve(_url, output_file)
-        print(f"Finish Downloading {_ontology}")
+        logging.info(f"Finish Downloading {_ontology}")
 
     def _build_url(_ontology: str) -> str:
         onto_ref_data = ontology_info[_ontology]
@@ -210,6 +217,10 @@ def _extract_ontology_term_metadata(onto: owlready2.entity.ThingClass) -> Dict[s
     return term_dict
 
 
+def get_ontology_file_name(ontology_name: str, ontology_version: str) -> str:
+    return f"{ontology_name}-ontology-{ontology_version}.json.gz"
+
+
 def _parse_ontologies(
     ontology_info: Any,
     working_dir: str = env.RAW_ONTOLOGY_DIR,
@@ -252,8 +263,8 @@ def _parse_ontologies(
             continue
         onto = _load_ontology_object(os.path.join(working_dir, onto_file))
         version = ontology_info[onto.name]["version"]
-        output_file = os.path.join(output_path, f"{onto.name}-ontology-{version}.json.gz")
-        print(f"Processing {output_file}")
+        output_file = os.path.join(output_path, get_ontology_file_name(onto.name, version))
+        logging.info(f"Processing {output_file}")
 
         onto_dict = _extract_ontology_term_metadata(onto)
 
@@ -262,12 +273,71 @@ def _parse_ontologies(
         yield output_file
 
 
+def update_ontology_info(ontology_info: Dict[str, Any]) -> Set[str]:
+    """
+    Update the ontology_info.json file by removing expired versions and returning a list of the ontology files that
+    can be removed
+    :param ontology_info:
+    :return: a list of ontology files that can be removed
+    """
+    expired = list_expired_cellxgene_schema_version(ontology_info)  # find expired cellxgene schema versions
+    current = set(ontology_info.keys()) - set(expired)  # find current cellxgene schema versions
+    logging.info("Expired versions:\n\t", "\t\n".join(expired))
+
+    def _get_ontology_files(schema_versions: List[str]) -> Set[str]:
+        """
+        find all ontologies that are in the list of schema_versions
+
+        :param schema_versions:
+        :return: ontology_files
+        """
+
+        ontology_files = set()
+        for version in schema_versions:
+            for ontology, info in ontology_info[version]["ontologies"].items():
+                ontology_files.add(get_ontology_file_name(ontology, info["version"]))
+        return ontology_files
+
+    expired_files = _get_ontology_files(expired)  # find all ontology files that are in the expired versions
+    current_files = _get_ontology_files(list(current))  # find all ontology files that are in the current versions
+    # find the ontology files that are in the expired versions but not in the current versions
+    remove_files = expired_files - current_files
+    # remove expired versions from ontology_info
+    for version in expired:
+        del ontology_info[version]
+    return remove_files
+
+
+def list_expired_cellxgene_schema_version(ontology_info: Dict[str, Any]) -> List[str]:
+    """
+    Lists cellxgene schema version that are deprecated and should be removed from the ontology_info.json file
+    :param ontology_info:
+    :return: a list of expired schema versions
+    """
+    expired_versions = []
+    now = datetime.now()
+    for schema_version in ontology_info:
+        deprecated_on = ontology_info[schema_version].get("deprecated_on")
+        if deprecated_on:
+            parsed_date = datetime.strptime(deprecated_on, "%Y-%m-%d")
+            expiration_date = parsed_date + timedelta(days=6 * 30)  # 6 months
+            if expiration_date < now:
+                expired_versions.append(schema_version)
+    return expired_versions
+
+
 # Download and parse ontology files upon execution
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    ontology_info = _get_ontology_info_file()
-    _download_ontologies(ontology_info)
-    _parse_ontologies(ontology_info)
+    ontology_info = get_ontology_info_file()
+    latest_ontology_version = ontology_info[_get_latest_version(ontology_info.keys())]
+    _download_ontologies(latest_ontology_version)
+    _parse_ontologies(latest_ontology_version)
+    expired_files = update_ontology_info(ontology_info)
+    logging.info("Removing expired files:\n\t", "\t\n".join(expired_files))
+    for file in expired_files:
+        os.remove(os.path.join(env.ONTOLOGY_ASSETS_DIR, file))
+    save_ontology_info(ontology_info)
     # validate against the schema
     schema_file = os.path.join(env.SCHEMA_DIR, "all_ontology_schema.json")
     registry = register_schemas()

--- a/tools/ontology-builder/tests/test_all_ontology_generator.py
+++ b/tools/ontology-builder/tests/test_all_ontology_generator.py
@@ -9,6 +9,7 @@ from all_ontology_generator import (
     _download_ontologies,
     _get_latest_version,
     _parse_ontologies,
+    deprecate_previous_cellxgene_schema_versions,
     get_ontology_info_file,
     list_expired_cellxgene_schema_version,
     update_ontology_info,
@@ -212,3 +213,23 @@ def test_update_ontology_info(mock_datetime):
     # Assert the result matches the expected expired versions
     assert ontology_info == expected_ontology_info
     assert removed_files == expected_removed_files
+
+
+def test_deprecate_previous_cellxgene_schema_versions(mock_datetime):
+    ontology_info = {
+        "v1": {},  # current version
+        "v2": {},  # not deprecated
+        "v3": {},  # multiple versions to deprecate
+        "v4": {"deprecated_on": "2023-01-01"},  # already deprecated
+    }
+    expected_ontology_info = {
+        "v1": {},  # unchanged
+        "v2": {"deprecated_on": "2024-01-01"},  # added deprecated_on
+        "v3": {"deprecated_on": "2024-01-01"},  # added deprecated_on
+        "v4": {"deprecated_on": "2023-01-01"},  # unchanged
+    }
+
+    # Call the function
+    deprecate_previous_cellxgene_schema_versions(ontology_info, "v1")
+
+    assert ontology_info == expected_ontology_info


### PR DESCRIPTION
## Reason for Change
- automate the cellxgene schema versions deprecation process.
- https://github.com/chanzuckerberg/cellxgene-ontology-guide/issues/170

## Changes

- add deprecation warning to API when older version of the cellxgene schema are used.
- add logic to all_ontology_generator.py to remove expired ontology files from repo, expired cellxgene schema versions from ontology_info.json, and deprecate the previous cellxgene schema version if a new version exists.

## Testing steps

- updated unit tests
- Need to verify that files will be removed by the GHA.

## Notes for Reviewer
