### PR TITLE
chore: move pytest configs to pyproject.toml

### DIFF
--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -39,5 +39,5 @@ release/pypi: build
 	python -m twine upload dist/*
 
 unit-tests:
-	python -m pytest tests
+	python -m pytest
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -47,3 +47,7 @@ root = "../.."  # relative to the location of the pyproject.toml file
 
 [tool.pytest.ini_options]
 pythonpath = ["src/cellxgene_ontology_guide"]
+testpaths = [
+    "tests",
+]
+

--- a/tools/coverage.mk
+++ b/tools/coverage.mk
@@ -5,7 +5,7 @@ export COVERAGE_RUN_ARGS:=--data-file=$(REPO_ROOT)/$(COVERAGE_DATA_FILE) --branc
 
 
 coverage/run:
-	coverage run $(COVERAGE_RUN_ARGS) -m pytest ./tests;
+	coverage run $(COVERAGE_RUN_ARGS) -m pytest;
 
 coverage/combine:
 	coverage combine --data-file=$(COVERAGE_DATA_FILE)

--- a/tools/ontology-builder/Makefile
+++ b/tools/ontology-builder/Makefile
@@ -1,7 +1,7 @@
 include ../coverage.mk
 
 unit-tests:
-	python -m pytest tests
+	python -m pytest
 
 install:
 	pip install -r requirements.txt

--- a/tools/ontology-builder/pyproject.toml
+++ b/tools/ontology-builder/pyproject.toml
@@ -1,4 +1,3 @@
 [tool.pytest.ini_options]
-pythonpath = [
-  "src"
-]
+pythonpath = ["src"]
+testpaths = ["tests"]


### PR DESCRIPTION
## Reason for Change

- moving pytest run configuration for unit tests into pyproject.toml. This is easier to maintain that in a makefile.

## Changes

- moving pytest run configuration for unit tests into pyproject.toml
- update coverage/run to use testpaths from pyproject.toml

## Testing steps

- verify coverage works and unit tests work for each test suite.

