### PR TITLE
feat: add term label to OntologyNode

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/entities.py
+++ b/api/python/src/cellxgene_ontology_guide/entities.py
@@ -37,8 +37,9 @@ class OntologyNode:
     Class to represent an ontology term and its subclasses
     """
 
-    def __init__(self, term_id: str):
+    def __init__(self, term_id: str, name: str):
         self._term_id = term_id
+        self._name = name
         self._children: List["OntologyNode"] = []
         self._term_counter: Counter[str] = Counter({self.term_id: 1})
 
@@ -48,6 +49,13 @@ class OntologyNode:
         Ontology term ID represented by this OntologyNode.
         """
         return self._term_id
+
+    @property
+    def name(self) -> str:
+        """
+        Human-readable label for ontology term represented by this OntologyNode.
+        """
+        return self._name
 
     @property
     def children(self) -> List["OntologyNode"]:
@@ -70,4 +78,8 @@ class OntologyNode:
         self._term_counter.update(child.term_counter)
 
     def to_dict(self) -> Dict[str, Any]:
-        return {self.term_id: [child.to_dict() for child in self.children]}
+        return {
+            "term_id": self.term_id,
+            "name": self.name,
+            "children": [child.to_dict() for child in self.children],
+        }

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -348,20 +348,19 @@ class OntologyParser:
         'CL:0000000'
         >>> root_node.to_dict() # doctest: +SKIP
         {
-            'CL:0000000': [
-                {'CL:0000001': [
-                    {'CL:0000004': [...]},
-                    {'CL:0000005': [...]},
-                    {'CL:0000006': [...]},
-                    {'CL:0000007': [...]},
-                    ...
-                ]},
-                {'CL:0000002': [
-                    {'CL:0000004': [...]},
-                    {'CL:0000005': [...]},
-                    ...
-                ]},
-                {'CL:0000003': []},
+            "term_id": "CL:0000000",
+            "name": "cell A",
+            "children": [
+                {
+                    "term_id": "CL:0000001",
+                    "name": "cell B",
+                    "children": [...],
+                },
+                {
+                    "term_id": "CL:0000002",
+                    "name": "cell C",
+                    "children": [...],
+                },
                 ...
             ]
         }
@@ -372,7 +371,8 @@ class OntologyParser:
         :return: OntologyNode representation of graph with term_id as root.
         """
         ontology_name = self._parse_ontology_name(term_id)
-        root = OntologyNode(term_id)
+        term_label = self.get_term_label(term_id)
+        root = OntologyNode(term_id, term_label)
         for candidate_descendant, candidate_metadata in self.cxg_schema.ontology(ontology_name).items():
             for ancestor, distance in candidate_metadata["ancestors"].items():
                 if ancestor == term_id and distance == 1:

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -288,23 +288,29 @@ def test_get_distance_between_terms(ontology_parser):
 def test_get_term_graph(ontology_parser):
     graph = ontology_parser.get_term_graph("CL:0000000")
     assert graph.to_dict() == {
-        "CL:0000000": [
+        "term_id": "CL:0000000",
+        "name": "cell A",
+        "children": [
             {
-                "CL:0000001": [
-                    {"CL:0000004": []},
-                    {"CL:0000005": []},
-                    {"CL:0000006": []},
-                    {"CL:0000007": []},
-                ]
+                "term_id": "CL:0000001",
+                "name": "cell B",
+                "children": [
+                    {"term_id": "CL:0000004", "name": "cell BC", "children": []},
+                    {"term_id": "CL:0000005", "name": "cell BC2", "children": []},
+                    {"term_id": "CL:0000006", "name": "cell B2", "children": []},
+                    {"term_id": "CL:0000007", "name": "cell B3", "children": []},
+                ],
             },
             {
-                "CL:0000002": [
-                    {"CL:0000004": []},
-                    {"CL:0000005": []},
-                ]
+                "term_id": "CL:0000002",
+                "name": "cell C",
+                "children": [
+                    {"term_id": "CL:0000004", "name": "cell BC", "children": []},
+                    {"term_id": "CL:0000005", "name": "cell BC2", "children": []},
+                ],
             },
-            {"CL:0000003": []},
-        ]
+            {"term_id": "CL:0000003", "name": "obsolete cell", "children": []},
+        ],
     }
 
     assert graph.term_counter == {


### PR DESCRIPTION
## Reason for Change

- Cell Guide uses term label in their subtree implementation, this simplifies their integration with COG

## Changes

- add "name" property to OntologyNode
- update dict representation of OntologyNode to accommodate this additional metadata on each node 

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.

## Notes for Reviewer
