### PR TITLE
chore: pull from github ref 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           manifest-file: ".release-please-manifest.json"
           config-file: "release-please-config.json"
-          target-branch: "main"
+          target-branch: ${{ github.ref }}
     outputs:
       ontology_assets_upload_url: ${{ steps.release.outputs.ontology-assets--upload_url }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
           fetch-depth: 1
       - name: Upload release asset
         uses: actions/upload-release-asset@v1
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Set up Python 3.11
         uses: actions/setup-python@v5


### PR DESCRIPTION
rather than main to avoid consistency issue if main is pushed in quick succession.
