### PR TITLE
fix: Preserve order of high_level_terms when matching against an input curated list of terms

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -222,8 +222,8 @@ class OntologyParser:
     def get_high_level_terms(self, term_id: str, high_level_terms: List[str]) -> List[str]:
         """
         Get the high-level ontology terms for a given term. High-level terms are defined as the ancestors of the term
-        that are part of the high-level ontology terms supported by cellxgene-ontology-guide. If more than 1 
-        high_level_term is matched, the returned list of matches preserves the order of the input high_level_terms list. 
+        that are part of the high-level ontology terms supported by cellxgene-ontology-guide. If more than 1
+        high_level_term is matched, the returned list of matches preserves the order of the input high_level_terms list.
         Raises ValueError if term ID is not valid member of a supported ontology.
 
         Example

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -222,8 +222,9 @@ class OntologyParser:
     def get_high_level_terms(self, term_id: str, high_level_terms: List[str]) -> List[str]:
         """
         Get the high-level ontology terms for a given term. High-level terms are defined as the ancestors of the term
-        that are part of the high-level ontology terms supported by cellxgene-ontology-guide. Raises ValueError if
-        term ID is not valid member of a supported ontology.
+        that are part of the high-level ontology terms supported by cellxgene-ontology-guide. If more than 1 
+        high_level_term is matched, the returned list of matches preserves the order of the input high_level_terms list. 
+        Raises ValueError if term ID is not valid member of a supported ontology.
 
         Example
         >>> from cellxgene_ontology_guide.ontology_parser import OntologyParser
@@ -238,7 +239,7 @@ class OntologyParser:
         if term_id in VALID_NON_ONTOLOGY_TERMS:
             return []
         ancestors = self.get_term_ancestors(term_id, include_self=True)
-        return [high_level_term for high_level_term in ancestors if high_level_term in high_level_terms]
+        return [high_level_term for high_level_term in high_level_terms if high_level_term in ancestors]
 
     def map_high_level_terms(self, term_ids: List[str], high_level_terms: List[str]) -> Dict[str, List[str]]:
         """

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -234,12 +234,19 @@ def test_map_term_description(ontology_parser):
     }
 
 
-def test_get_high_level_terms(ontology_parser):
-    high_level_terms = ["CL:0000000", "CL:0000001"]
-    assert ontology_parser.get_high_level_terms("CL:0000004", high_level_terms) == ["CL:0000000", "CL:0000001"]
-    assert ontology_parser.get_high_level_terms("CL:0000008", high_level_terms) == []
-    assert ontology_parser.get_high_level_terms("CL:0000000", high_level_terms) == ["CL:0000000"]
-    assert ontology_parser.get_high_level_terms("na", high_level_terms) == []
+@pytest.mark.parametrize(
+    "term_id,high_level_terms,expected",
+    [
+        ("CL:0000004", ["CL:0000000", "CL:0000001"], ["CL:0000000", "CL:0000001"]),
+        ("CL:0000004", ["CL:0000001", "CL:0000000"], ["CL:0000001", "CL:0000000"]),  # preserve high level term order
+        ("CL:0000008", ["CL:0000000", "CL:0000001"], []),
+        ("CL:0000000", ["CL:0000000", "CL:0000001"], ["CL:0000000"]),
+        ("CL:0000001", ["CL:0000000", "CL:0000001"], ["CL:0000000", "CL:0000001"]),
+        ("na", ["CL:0000000", "CL:0000001"], []),
+    ],
+)
+def test_get_high_level_terms(ontology_parser, term_id, high_level_terms, expected):
+    assert ontology_parser.get_high_level_terms(term_id, high_level_terms) == expected
 
 
 def test_map_high_level_terms(ontology_parser):


### PR DESCRIPTION
## Reason for Change

- Account for census mapper's curated tissue general list being designed such that order of terms matters (see comment [here](https://github.com/chanzuckerberg/cellxgene-census/blob/861444a2100333459e7cdfed63519facc14a9f42/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/tissue_mapper.py#L13-L14))
## Changes

- return mapped high_level_terms matching an input term ID in the same order as the curated list passed in

## Testing steps

- unit tests

## Notes for Reviewer
