### PR TITLE
fix: remove setuptools-scm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,6 @@ on:
     branches:
       - main
 
-  pull_request:
-    branches:
-      - "*"
-
 permissions:
   contents: write
   pull-requests: write
@@ -26,7 +22,7 @@ jobs:
         with:
           manifest-file: ".release-please-manifest.json"
           config-file: "release-please-config.json"
-          target-branch: "tsmith/remove-setuptool-scm"
+          target-branch: "main"
     outputs:
       ontology_assets_upload_url: ${{ steps.release.outputs.ontology-assets--upload_url }}
       paths_released: ${{ steps.release.outputs.paths_released }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - main
 
+  pull_request:
+    branches:
+      - "*"
+
 permissions:
   contents: write
   pull-requests: write
@@ -22,7 +26,7 @@ jobs:
         with:
           manifest-file: ".release-please-manifest.json"
           config-file: "release-please-config.json"
-          target-branch: "main"
+          target-branch: "tsmith/remove-setuptool-scm"
     outputs:
       ontology_assets_upload_url: ${{ steps.release.outputs.ontology-assets--upload_url }}
       paths_released: ${{ steps.release.outputs.paths_released }}

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=69", "setuptools-scm>=8"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cellxgene_ontology_guide"
-dynamic = ["version"]
+version = "0.7.0"
 description = "Access ontology metadata used by CZ cellxgene"
 authors = [
     { name = "Chan Zuckerberg Initiative Foundation", email = "cellxgene@chanzuckerberg.com" }
@@ -40,10 +40,10 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.json", "*.json.gz"]
 
-[tool.setuptools_scm]
-version_file = "src/cellxgene_ontology_guide/_version.py"
-version_scheme = "python-simplified-semver"
-root = "../.."  # relative to the location of the pyproject.toml file
+#[tool.setuptools_scm]
+#version_file = "src/cellxgene_ontology_guide/_version.py"
+#version_scheme = "python-simplified-semver"
+#root = "../.."  # relative to the location of the pyproject.toml file
 
 [tool.pytest.ini_options]
 pythonpath = ["src/cellxgene_ontology_guide"]

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -40,11 +40,6 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.json", "*.json.gz"]
 
-#[tool.setuptools_scm]
-#version_file = "src/cellxgene_ontology_guide/_version.py"
-#version_scheme = "python-simplified-semver"
-#root = "../.."  # relative to the location of the pyproject.toml file
-
 [tool.pytest.ini_options]
 pythonpath = ["src/cellxgene_ontology_guide"]
 addopts = "--doctest-modules"

--- a/api/python/src/cellxgene_ontology_guide/__init__.py
+++ b/api/python/src/cellxgene_ontology_guide/__init__.py
@@ -19,7 +19,5 @@ repository.
 .. include:: ../../CHANGELOG.md
 """
 
-import cellxgene_ontology_guide._version as version
-
-__version__ = version.__version__
+__version__ = "0.7.0"
 __all__ = ["curated_ontology_term_lists", "entities", "ontology_parser", "supported_versions"]

--- a/api/python/tests/test_version.py
+++ b/api/python/tests/test_version.py
@@ -1,5 +1,0 @@
-import cellxgene_ontology_guide
-
-
-def test_version():
-    assert cellxgene_ontology_guide.__version__

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,7 +22,8 @@
   ],
   "packages": {
     "api/python": {
-      "package-name": "python-api"
+      "package-name": "python-api",
+      "release-type": "python"
     },
     "ontology-assets": {
       "package-name": "ontology-assets"


### PR DESCRIPTION
## Reason for Change

- setuptools-scm and release-please don't play nice together. The [git command ](https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm.git.DEFAULT_DESCRIBE) command used by setuptools-scm is unable to parse the python-api version if multiple tags are on the same commit. This causes pypi releases to fail if they are released the same time as ontology-assets.

## Changes

- remove setuptool-scm from the python-api build chain. 
- use release-please to update the python version values in the API

## Testing steps
-  Ran release-please. This is what a release would look like https://github.com/chanzuckerberg/cellxgene-ontology-guide/pull/198
- verified unit tests pass

## Notes for Reviewer

### Pros
- reduces number of dependencies
- automated pypi releases will work reliably

### Cons
- When build locally on a dirty branch, the version of COG will still be whatever the last release was. If a users does try to push this version to pypi it will fail because that version should already be release.
