### PR TITLE
feat: fetch term ID by term label

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -24,7 +24,9 @@ class OntologyParser:
         is loaded.
         """
         self.cxg_schema = CXGSchema(version=schema_version) if schema_version else CXGSchema()
-        self.term_label_to_id_map = {ontology_name: dict() for ontology_name in self.cxg_schema.supported_ontologies}
+        self.term_label_to_id_map: Dict[str, str] = {
+            ontology_name: dict() for ontology_name in self.cxg_schema.supported_ontologies
+        }
 
     def get_term_label_to_id_map(self, ontology_name: str) -> Dict[str, str]:
         """
@@ -642,4 +644,3 @@ class OntologyParser:
         """
         ontology_term_label_to_id_map = self.get_term_label_to_id_map(ontology_name)
         return ontology_term_label_to_id_map.get(term_label)
-

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -24,7 +24,7 @@ class OntologyParser:
         is loaded.
         """
         self.cxg_schema = CXGSchema(version=schema_version) if schema_version else CXGSchema()
-        self.term_label_to_id_map: Dict[str, str] = {
+        self.term_label_to_id_map: Dict[str, Dict[str, str]] = {
             ontology_name: dict() for ontology_name in self.cxg_schema.supported_ontologies
         }
 

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -371,3 +371,29 @@ def test_get_term_graph(ontology_parser):
         "CL:0000006": 1,
         "CL:0000007": 1,
     }
+
+
+def test_get_term_label_to_id_map(ontology_parser):
+    term_label_to_id_map_expected = {
+        "cell A": "CL:0000000",
+        "cell B": "CL:0000001",
+        "cell C": "CL:0000002",
+        "obsolete cell": "CL:0000003",
+        "cell BC": "CL:0000004",
+        "cell BC2": "CL:0000005",
+        "cell B2": "CL:0000006",
+        "cell B3": "CL:0000007",
+        "cell unrelated": "CL:0000008",
+    }
+    assert ontology_parser.get_term_label_to_id_map("CL") == term_label_to_id_map_expected
+    assert ontology_parser.term_label_to_id_map["CL"] == term_label_to_id_map_expected
+
+
+def test_get_term_id_by_label(ontology_parser):
+    assert ontology_parser.get_term_id_by_label("cell A", "CL") == "CL:0000000"
+    assert ontology_parser.get_term_id_by_label("cell Z", "CL") is None
+
+
+def test_get_term_id_by_label__unsupported_ontology_name(ontology_parser):
+    with pytest.raises(ValueError):
+        ontology_parser.get_term_id_by_label("gene A", "GO")


### PR DESCRIPTION
## Reason for Change

- #206

## Changes

- add get_term_label_to_id_map to generate + return full term label to term ID maps by ontology_name, and cache them after they are generated once
- add get_term_id_by_label function to fetch single term IDs by their term label

## Testing steps

- unit tests

## Notes for Reviewer
