### PR TITLE
feat: query cross-ontology terms imported into a supported ontology

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -40,7 +40,7 @@ class OntologyParser:
 
         :param ontology_name: str name of ontology to get map of term labels to term IDs
         """
-        ontology_name = self._get_supported_ontology_name(ontology_name)
+        ontology_name: Optional[str] = self._get_supported_ontology_name(ontology_name)
         if not ontology_name:
             raise ValueError(f"{ontology_name} is not a supported ontology, its metadata cannot be fetched.")
 
@@ -65,7 +65,7 @@ class OntologyParser:
             raise ValueError(f"{term_id} does not conform to expected regex pattern {pattern} and cannot be queried.")
 
         ontology_term_prefix = term_id.split(":")[0]
-        ontology_name = self._get_supported_ontology_name(ontology_term_prefix)
+        ontology_name: Optional[str] = self._get_supported_ontology_name(ontology_term_prefix)
         if not ontology_name:
             raise ValueError(f"{term_id} is not part of a supported ontology, its metadata cannot be fetched.")
 
@@ -89,7 +89,6 @@ class OntologyParser:
         elif ontology_term_prefix in self.cxg_schema.imported_ontologies:
             return self.cxg_schema.imported_ontologies[ontology_term_prefix]
         return None
-
 
     def is_valid_term_id(self, term_id: str, ontology: Optional[str] = None) -> bool:
         """

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -84,10 +84,9 @@ class OntologyParser:
         :return: str name of ontology that term belongs to, or None if it is not directly supported nor imported in
         a supported ontology in the CxG schema.
         """
-        supported_ontology_name: Optional[str] = self.cxg_schema.supported_ontologies.get(ontology_term_prefix)
-        if supported_ontology_name:
-            return supported_ontology_name
-        supported_ontology_name = self.cxg_schema.imported_ontologies.get(ontology_term_prefix)
+        if ontology_term_prefix in self.cxg_schema.supported_ontologies:
+            return ontology_term_prefix
+        supported_ontology_name: Optional[str] = self.cxg_schema.imported_ontologies.get(ontology_term_prefix)
         return supported_ontology_name
 
     def is_valid_term_id(self, term_id: str, ontology: Optional[str] = None) -> bool:

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -84,11 +84,11 @@ class OntologyParser:
         :return: str name of ontology that term belongs to, or None if it is not directly supported nor imported in
         a supported ontology in the CxG schema.
         """
-        if ontology_term_prefix in self.cxg_schema.supported_ontologies:
-            return ontology_term_prefix
-        elif supported_ontology_name := self.cxg_schema.imported_ontologies.get(ontology_term_prefix):
+        supported_ontology_name: Optional[str] = self.cxg_schema.supported_ontologies.get(ontology_term_prefix)
+        if supported_ontology_name:
             return supported_ontology_name
-        return None
+        supported_ontology_name = self.cxg_schema.imported_ontologies.get(ontology_term_prefix)
+        return supported_ontology_name
 
     def is_valid_term_id(self, term_id: str, ontology: Optional[str] = None) -> bool:
         """

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -86,8 +86,8 @@ class OntologyParser:
         """
         if ontology_term_prefix in self.cxg_schema.supported_ontologies:
             return ontology_term_prefix
-        elif ontology_term_prefix in self.cxg_schema.imported_ontologies:
-            return self.cxg_schema.imported_ontologies[ontology_term_prefix]
+        elif supported_ontology_name := self.cxg_schema.imported_ontologies.get(ontology_term_prefix):
+            return supported_ontology_name
         return None
 
     def is_valid_term_id(self, term_id: str, ontology: Optional[str] = None) -> bool:

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -40,7 +40,8 @@ class OntologyParser:
 
         :param ontology_name: str name of ontology to get map of term labels to term IDs
         """
-        if ontology_name not in self.cxg_schema.supported_ontologies:
+        ontology_name = self._get_supported_ontology_name(ontology_name)
+        if not ontology_name:
             raise ValueError(f"{ontology_name} is not a supported ontology, its metadata cannot be fetched.")
 
         if self.term_label_to_id_map[ontology_name]:
@@ -63,11 +64,32 @@ class OntologyParser:
         if not re.match(pattern, term_id):
             raise ValueError(f"{term_id} does not conform to expected regex pattern {pattern} and cannot be queried.")
 
-        ontology_name = term_id.split(":")[0]
-        if ontology_name not in self.cxg_schema.supported_ontologies:
+        ontology_term_prefix = term_id.split(":")[0]
+        ontology_name = self._get_supported_ontology_name(ontology_term_prefix)
+        if not ontology_name:
             raise ValueError(f"{term_id} is not part of a supported ontology, its metadata cannot be fetched.")
 
         return ontology_name
+
+    def _get_supported_ontology_name(self, ontology_term_prefix: str) -> Optional[str]:
+        """
+        Get the source ontology name for a given ontology term prefix, if it is supported by the CxG schema.
+
+        If ontology_term_prefix is directly supported by the CxG schema, returns ontology_term_prefix.
+        If ontology_term_prefix is supported as an import from another ontology, returns the name of the source ontology
+        it is imported in.
+        Otherwise, returns None.
+
+        :param ontology_term_prefix: str ontology term prefix to check
+        :return: str name of ontology that term belongs to, or None if it is not directly supported nor imported in
+        a supported ontology in the CxG schema.
+        """
+        if ontology_term_prefix in self.cxg_schema.supported_ontologies:
+            return ontology_term_prefix
+        elif ontology_term_prefix in self.cxg_schema.imported_ontologies:
+            return self.cxg_schema.imported_ontologies[ontology_term_prefix]
+        return None
+
 
     def is_valid_term_id(self, term_id: str, ontology: Optional[str] = None) -> bool:
         """

--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -40,17 +40,17 @@ class OntologyParser:
 
         :param ontology_name: str name of ontology to get map of term labels to term IDs
         """
-        ontology_name: Optional[str] = self._get_supported_ontology_name(ontology_name)
-        if not ontology_name:
-            raise ValueError(f"{ontology_name} is not a supported ontology, its metadata cannot be fetched.")
+        supported_ontology_name: Optional[str] = self._get_supported_ontology_name(ontology_name)
+        if not supported_ontology_name:
+            raise ValueError(f"{supported_ontology_name} is not a supported ontology, its metadata cannot be fetched.")
 
-        if self.term_label_to_id_map[ontology_name]:
-            return self.term_label_to_id_map[ontology_name]
+        if self.term_label_to_id_map[supported_ontology_name]:
+            return self.term_label_to_id_map[supported_ontology_name]
 
-        for term_id, term_metadata in self.cxg_schema.ontology(ontology_name).items():
-            self.term_label_to_id_map[ontology_name][term_metadata["label"]] = term_id
+        for term_id, term_metadata in self.cxg_schema.ontology(supported_ontology_name).items():
+            self.term_label_to_id_map[supported_ontology_name][term_metadata["label"]] = term_id
 
-        return self.term_label_to_id_map[ontology_name]
+        return self.term_label_to_id_map[supported_ontology_name]
 
     def _parse_ontology_name(self, term_id: str) -> str:
         """

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -58,8 +58,9 @@ class CXGSchema:
     supported_ontologies: Dict[str, Any]
     """A dictionary of supported ontologies for the schema version."""
     imported_ontologies: Dict[str, str]
-    """A dictionary of ontologies with terms imported into supported ontologies, mapped to the supported ontology
-    importing them."""
+    """In our supported ontologies, the CxG schema can support terms imported from different ontologies. 
+    This dictionary maps these 'additional ontologies' to their supported ontology name. For example, 
+    for ZFS ontology terms imported into the ZFA ontology, imported_ontologies would be {"ZFS":"ZFA", ...}"""
     ontology_file_names: Dict[str, str]
     """A dictionary of ontology names and their corresponding file names."""
 

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -75,6 +75,11 @@ class CXGSchema:
 
         self.version = _version
         self.supported_ontologies = ontology_info[_version]["ontologies"]
+        self.imported_ontologies = {
+            imported_ontology: ontology
+            for ontology, info in self.supported_ontologies.items()
+            for imported_ontology in info.get("additional_ontologies", [])
+        }
         self.ontology_file_names: Dict[str, str] = {}
         self.deprecated_on = ontology_info[_version].get("deprecated_on")
         if self.deprecated_on:
@@ -87,6 +92,9 @@ class CXGSchema:
 
     def ontology(self, name: str) -> Any:
         """Return the ontology terms for the given ontology name. Load from the file cache if available.
+
+        Does not support "additional ontologies" of another ontology.
+
         :param name: str name of the ontology to get the terms for
         :return: dict representation of the ontology terms
         """

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -57,6 +57,9 @@ class CXGSchema:
     """The schema version used by the class instance."""
     supported_ontologies: Dict[str, Any]
     """A dictionary of supported ontologies for the schema version."""
+    imported_ontologies: Dict[str, str]
+    """A dictionary of ontologies with terms imported into supported ontologies, mapped to the supported ontology
+    importing them."""
     ontology_file_names: Dict[str, str]
     """A dictionary of ontology names and their corresponding file names."""
 
@@ -75,7 +78,7 @@ class CXGSchema:
 
         self.version = _version
         self.supported_ontologies = ontology_info[_version]["ontologies"]
-        self.imported_ontologies: Dict[str, str] = {
+        self.imported_ontologies = {
             imported_ontology: ontology
             for ontology, info in self.supported_ontologies.items()
             for imported_ontology in info.get("additional_ontologies", [])

--- a/api/python/src/cellxgene_ontology_guide/supported_versions.py
+++ b/api/python/src/cellxgene_ontology_guide/supported_versions.py
@@ -75,7 +75,7 @@ class CXGSchema:
 
         self.version = _version
         self.supported_ontologies = ontology_info[_version]["ontologies"]
-        self.imported_ontologies = {
+        self.imported_ontologies: Dict[str, str] = {
             imported_ontology: ontology
             for ontology, info in self.supported_ontologies.items()
             for imported_ontology in info.get("additional_ontologies", [])

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -51,7 +51,7 @@ def ontology_dict_with_imports():
             "comments": ["this is an HANCESTRO term, not imported"],
             "term_tracker": "http://example.com/issue/HANCESTRO/1234",
             "synonyms": ["root ancestry synonym"],
-            "deprecated": False
+            "deprecated": False,
         },
         "AfPO:0000000": {
             "ancestors": {"HANCESTRO:0000000": 1},
@@ -61,12 +61,12 @@ def ontology_dict_with_imports():
             "comments": ["this is an AfPO term imported into HANCESTRO"],
             "synonyms": ["specialized ancestry synonym"],
             "term_tracker": "http://example.com/issue/AfPO/1234",
-            "replaced_by": "AfPO:0000001"
+            "replaced_by": "AfPO:0000001",
         },
         "HANCESTRO:0000001": {
             "ancestors": {"HANCESTRO:0000000": 2, "AfPO:0000000": 1},
             "label": "root ontology descendant of specialized ancestry type",
-            "deprecated": False
+            "deprecated": False,
         },
     }
 
@@ -81,7 +81,7 @@ def mock_CXGSchema(ontology_dict, ontology_dict_with_imports, mock_load_supporte
                     "version": "2024-01-01",
                     "source": "http://example.com",
                     "filename": "cl.owl",
-                    "additional_ontologies": ["AfPO"]
+                    "additional_ontologies": ["AfPO"],
                 },
             }
         }
@@ -89,7 +89,7 @@ def mock_CXGSchema(ontology_dict, ontology_dict_with_imports, mock_load_supporte
     cxg_schema = CXGSchema()
     cxg_schema.ontology_file_names = {
         "CL": "CL-ontology-2024-01-01.json.gz",
-        "HANCESTRO": "HANCESTRO-ontology-2024-01-01.json.gz"
+        "HANCESTRO": "HANCESTRO-ontology-2024-01-01.json.gz",
     }
 
     def get_mock_ontology_dict(file_name):
@@ -113,6 +113,7 @@ def ontology_parser(mock_CXGSchema):
 def test_parse_ontology_name(ontology_parser):
     assert ontology_parser._parse_ontology_name("CL:0000001") == "CL"
 
+
 @pytest.mark.parametrize("term_id", ["AfPO:0000001", "HANCESTRO:0000000"])
 def test_parse_ontology_name__imported_term(ontology_parser, term_id):
     assert ontology_parser._parse_ontology_name(term_id) == "HANCESTRO"
@@ -129,9 +130,8 @@ def test_parse_ontology_name__not_supported(ontology_parser):
 
 
 @pytest.mark.parametrize(
-    "term_id,expected", [
-        ("CL:0000001", True), ("CL:0000003", True), ("CL:0000009", False), ("GO:0000001", False), ("AfPO:0000000", True)
-    ]
+    "term_id,expected",
+    [("CL:0000001", True), ("CL:0000003", True), ("CL:0000009", False), ("GO:0000001", False), ("AfPO:0000000", True)],
 )
 def test_is_valid_term_id(ontology_parser, term_id, expected):
     assert ontology_parser.is_valid_term_id(term_id) == expected
@@ -140,9 +140,13 @@ def test_is_valid_term_id(ontology_parser, term_id, expected):
 @pytest.mark.parametrize(
     "term_id,ontology,expected",
     [
-        ("CL:0000001", "CL", True), ("CL:0000001", "UBERON", False), ("GO:0000001", "GO", False),
-        ("AfPO:0000000", "HANCESTRO", True), ("AfPO:0000000", "AfPO", False), ("HANCESTRO:0000001", "AfPO", False),
-    ]
+        ("CL:0000001", "CL", True),
+        ("CL:0000001", "UBERON", False),
+        ("GO:0000001", "GO", False),
+        ("AfPO:0000000", "HANCESTRO", True),
+        ("AfPO:0000000", "AfPO", False),
+        ("HANCESTRO:0000001", "AfPO", False),
+    ],
 )
 def test_is_valid_term_id__with_ontology(ontology_parser, term_id, ontology, expected):
     assert ontology_parser.is_valid_term_id(term_id, ontology) == expected
@@ -308,7 +312,9 @@ def test_get_term_label(ontology_parser):
 
 
 def test_map_term_labels(ontology_parser):
-    assert ontology_parser.map_term_labels(["CL:0000000", "CL:0000004", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]) == {
+    assert ontology_parser.map_term_labels(
+        ["CL:0000000", "CL:0000004", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]
+    ) == {
         "CL:0000000": "cell A",
         "CL:0000004": "cell BC",
         "AfPO:0000000": "specialized ancestry type",
@@ -345,7 +351,9 @@ def test_get_term_synonyms(ontology_parser):
 
 
 def test_map_term_synonyms(ontology_parser):
-    assert ontology_parser.map_term_synonyms(["CL:0000000", "CL:0000001", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]) == {
+    assert ontology_parser.map_term_synonyms(
+        ["CL:0000000", "CL:0000001", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]
+    ) == {
         "CL:0000000": [],
         "CL:0000001": ["cell Beta", "cell Bravo"],
         "AfPO:0000000": ["specialized ancestry synonym"],
@@ -412,9 +420,9 @@ def test_get_lowest_common_ancestors(ontology_parser):
     assert ontology_parser.get_lowest_common_ancestors(term_id_1="CL:0000001", term_id_2="CL:0000008") == []
 
     # diff ontology terms with a common ancestor
-    assert ontology_parser.get_lowest_common_ancestors(
-        term_id_1="AfPO:0000000", term_id_2="HANCESTRO:0000001"
-    ) == ["AfPO:0000000"]
+    assert ontology_parser.get_lowest_common_ancestors(term_id_1="AfPO:0000000", term_id_2="HANCESTRO:0000001") == [
+        "AfPO:0000000"
+    ]
 
 
 def test_get_distance_between_terms(ontology_parser):
@@ -436,8 +444,14 @@ def test_get_distance_between_terms(ontology_parser):
 
 @pytest.mark.parametrize(
     "term_id,expected",
-    [("CL:0000005", ["CL:0000001", "CL:0000002"]), ("CL:0000002", ["CL:0000000"]), ("CL:0000000", []), ("unknown", []),
-     ("AfPO:0000000", ["HANCESTRO:0000000"]), ("HANCESTRO:0000001", ["AfPO:0000000"])],
+    [
+        ("CL:0000005", ["CL:0000001", "CL:0000002"]),
+        ("CL:0000002", ["CL:0000000"]),
+        ("CL:0000000", []),
+        ("unknown", []),
+        ("AfPO:0000000", ["HANCESTRO:0000000"]),
+        ("HANCESTRO:0000001", ["AfPO:0000000"]),
+    ],
 )
 def test_get_term_parents(ontology_parser, term_id, expected):
     assert ontology_parser.get_term_parents(term_id) == expected
@@ -445,8 +459,13 @@ def test_get_term_parents(ontology_parser, term_id, expected):
 
 @pytest.mark.parametrize(
     "term_id,expected",
-    [("CL:0000000", ["CL:0000001", "CL:0000002", "CL:0000003"]), ("CL:0000005", []), ("unknown", []),
-     ("AfPO:0000000", ["HANCESTRO:0000001"]), ("HANCESTRO:0000000", ["AfPO:0000000"])],
+    [
+        ("CL:0000000", ["CL:0000001", "CL:0000002", "CL:0000003"]),
+        ("CL:0000005", []),
+        ("unknown", []),
+        ("AfPO:0000000", ["HANCESTRO:0000001"]),
+        ("HANCESTRO:0000000", ["AfPO:0000000"]),
+    ],
 )
 def test_get_term_children(ontology_parser, term_id, expected):
     assert ontology_parser.get_term_children(term_id) == expected
@@ -497,7 +516,13 @@ def test_get_term_graph__imported_ontology(ontology_parser):
     assert graph.to_dict() == {
         "term_id": "AfPO:0000000",
         "name": "specialized ancestry type",
-        "children": [{"term_id": "HANCESTRO:0000001", "name": "root ontology descendant of specialized ancestry type", "children": []}],
+        "children": [
+            {
+                "term_id": "HANCESTRO:0000001",
+                "name": "root ontology descendant of specialized ancestry type",
+                "children": [],
+            }
+        ],
     }
 
     assert graph.term_counter == {

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -371,6 +371,8 @@ def test_map_term_synonyms(ontology_parser):
         ("CL:0000008", ["CL:0000000", "CL:0000001"], []),
         ("CL:0000000", ["CL:0000000", "CL:0000001"], ["CL:0000000"]),
         ("CL:0000001", ["CL:0000000", "CL:0000001"], ["CL:0000000", "CL:0000001"]),
+        ("HANCESTRO:0000001", ["HANCESTRO:0000000", "AfPO:0000000"], ["HANCESTRO:0000000", "AfPO:0000000"]),
+        ("AfPO:0000000", ["HANCESTRO:0000000", "HANCESTRO:0000001"], ["HANCESTRO:0000000"]),
         ("na", ["CL:0000000", "CL:0000001"], []),
     ],
 )
@@ -392,12 +394,21 @@ def test_get_highest_level_term(ontology_parser):
     assert ontology_parser.get_highest_level_term("CL:0000008", high_level_terms) is None
     assert ontology_parser.get_highest_level_term("na", high_level_terms) is None
 
+    assert (
+        ontology_parser.get_highest_level_term("AfPO:0000000", ["HANCESTRO:0000000", "AfPO:0000000"])
+        == "HANCESTRO:0000000"
+    )
+
 
 def test_map_highest_level_term(ontology_parser):
     assert ontology_parser.map_highest_level_term(
         term_ids=["CL:0000000", "CL:0000008", "CL:0000004"],
         high_level_terms=["CL:0000000", "CL:0000001"],
     ) == {"CL:0000000": "CL:0000000", "CL:0000008": None, "CL:0000004": "CL:0000000"}
+    assert ontology_parser.map_highest_level_term(
+        term_ids=["AfPO:0000000", "HANCESTRO:0000001"],
+        high_level_terms=["HANCESTRO:0000000", "AfPO:0000000"],
+    ) == {"AfPO:0000000": "HANCESTRO:0000000", "HANCESTRO:0000001": "HANCESTRO:0000000"}
 
 
 def test_get_lowest_common_ancestors(ontology_parser):

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -411,6 +411,11 @@ def test_get_lowest_common_ancestors(ontology_parser):
     # disjoint
     assert ontology_parser.get_lowest_common_ancestors(term_id_1="CL:0000001", term_id_2="CL:0000008") == []
 
+    # diff ontology terms with a common ancestor
+    assert ontology_parser.get_lowest_common_ancestors(
+        term_id_1="AfPO:0000000", term_id_2="HANCESTRO:0000001"
+    ) == ["AfPO:0000000"]
+
 
 def test_get_distance_between_terms(ontology_parser):
     # distance when root node is lca
@@ -424,6 +429,9 @@ def test_get_distance_between_terms(ontology_parser):
 
     # disjoint distance
     assert ontology_parser.get_distance_between_terms(term_id_1="CL:0000001", term_id_2="CL:0000008") == -1
+
+    # diff ontology terms
+    assert ontology_parser.get_distance_between_terms(term_id_1="AfPO:0000000", term_id_2="HANCESTRO:0000001") == 1
 
 
 @pytest.mark.parametrize(

--- a/api/python/tests/test_ontology_parser.py
+++ b/api/python/tests/test_ontology_parser.py
@@ -42,13 +42,64 @@ def ontology_dict():
 
 
 @pytest.fixture
-def mock_CXGSchema(ontology_dict, mock_load_supported_versions, mock_load_ontology_file):
+def ontology_dict_with_imports():
+    return {
+        "HANCESTRO:0000000": {
+            "ancestors": {},
+            "label": "root ancestry type",
+            "description": "This is a root ancestry type.",
+            "comments": ["this is an HANCESTRO term, not imported"],
+            "term_tracker": "http://example.com/issue/HANCESTRO/1234",
+            "synonyms": ["root ancestry synonym"],
+            "deprecated": False
+        },
+        "AfPO:0000000": {
+            "ancestors": {"HANCESTRO:0000000": 1},
+            "label": "specialized ancestry type",
+            "description": "This is a specialized ancestry type.",
+            "deprecated": False,
+            "comments": ["this is an AfPO term imported into HANCESTRO"],
+            "synonyms": ["specialized ancestry synonym"],
+            "term_tracker": "http://example.com/issue/AfPO/1234",
+            "replaced_by": "AfPO:0000001"
+        },
+        "HANCESTRO:0000001": {
+            "ancestors": {"HANCESTRO:0000000": 2, "AfPO:0000000": 1},
+            "label": "root ontology descendant of specialized ancestry type",
+            "deprecated": False
+        },
+    }
+
+
+@pytest.fixture
+def mock_CXGSchema(ontology_dict, ontology_dict_with_imports, mock_load_supported_versions, mock_load_ontology_file):
     mock_load_supported_versions.return_value = {
-        "5.0.0": {"ontologies": {"CL": {"version": "2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}}
+        "5.0.0": {
+            "ontologies": {
+                "CL": {"version": "2024-01-01", "source": "http://example.com", "filename": "cl.owl"},
+                "HANCESTRO": {
+                    "version": "2024-01-01",
+                    "source": "http://example.com",
+                    "filename": "cl.owl",
+                    "additional_ontologies": ["AfPO"]
+                },
+            }
+        }
     }
     cxg_schema = CXGSchema()
-    cxg_schema.ontology_file_names = {"CL": "CL-ontology-2024-01-01.json.gz"}
-    mock_load_ontology_file.return_value = ontology_dict
+    cxg_schema.ontology_file_names = {
+        "CL": "CL-ontology-2024-01-01.json.gz",
+        "HANCESTRO": "HANCESTRO-ontology-2024-01-01.json.gz"
+    }
+
+    def get_mock_ontology_dict(file_name):
+        if "CL" in file_name:
+            return ontology_dict
+        if "HANCESTRO" in file_name:
+            return ontology_dict_with_imports
+        return None
+
+    mock_load_ontology_file.side_effect = get_mock_ontology_dict
 
     with patch("cellxgene_ontology_guide.ontology_parser.CXGSchema", return_value=cxg_schema) as mock:
         yield mock
@@ -62,6 +113,10 @@ def ontology_parser(mock_CXGSchema):
 def test_parse_ontology_name(ontology_parser):
     assert ontology_parser._parse_ontology_name("CL:0000001") == "CL"
 
+@pytest.mark.parametrize("term_id", ["AfPO:0000001", "HANCESTRO:0000000"])
+def test_parse_ontology_name__imported_term(ontology_parser, term_id):
+    assert ontology_parser._parse_ontology_name(term_id) == "HANCESTRO"
+
 
 def test_parse_ontology_name__wrong_format(ontology_parser):
     with pytest.raises(ValueError):
@@ -74,7 +129,9 @@ def test_parse_ontology_name__not_supported(ontology_parser):
 
 
 @pytest.mark.parametrize(
-    "term_id,expected", [("CL:0000001", True), ("CL:0000003", True), ("CL:0000009", False), ("GO:0000001", False)]
+    "term_id,expected", [
+        ("CL:0000001", True), ("CL:0000003", True), ("CL:0000009", False), ("GO:0000001", False), ("AfPO:0000000", True)
+    ]
 )
 def test_is_valid_term_id(ontology_parser, term_id, expected):
     assert ontology_parser.is_valid_term_id(term_id) == expected
@@ -82,7 +139,10 @@ def test_is_valid_term_id(ontology_parser, term_id, expected):
 
 @pytest.mark.parametrize(
     "term_id,ontology,expected",
-    [("CL:0000001", "CL", True), ("CL:0000001", "UBERON", False), ("GO:0000001", "GO", False)],
+    [
+        ("CL:0000001", "CL", True), ("CL:0000001", "UBERON", False), ("GO:0000001", "GO", False),
+        ("AfPO:0000000", "HANCESTRO", True), ("AfPO:0000000", "AfPO", False), ("HANCESTRO:0000001", "AfPO", False),
+    ]
 )
 def test_is_valid_term_id__with_ontology(ontology_parser, term_id, ontology, expected):
     assert ontology_parser.is_valid_term_id(term_id, ontology) == expected
@@ -97,6 +157,8 @@ def test_get_term_ancestors(ontology_parser):
         "CL:0000004",
     ]
     assert ontology_parser.get_term_ancestors("unknown", include_self=True) == []
+    assert ontology_parser.get_term_ancestors("AfPO:0000000") == ["HANCESTRO:0000000"]
+    assert ontology_parser.get_term_ancestors("HANCESTRO:0000001") == ["HANCESTRO:0000000", "AfPO:0000000"]
 
 
 def test_map_term_ancestors(ontology_parser):
@@ -108,6 +170,10 @@ def test_map_term_ancestors(ontology_parser):
         "CL:0000000": ["CL:0000000"],
         "CL:0000004": ["CL:0000000", "CL:0000001", "CL:0000002", "CL:0000004"],
         "unknown": [],
+    }
+    assert ontology_parser.map_term_ancestors(["AfPO:0000000", "HANCESTRO:0000001"]) == {
+        "AfPO:0000000": ["HANCESTRO:0000000"],
+        "HANCESTRO:0000001": ["HANCESTRO:0000000", "AfPO:0000000"],
     }
 
 
@@ -124,6 +190,11 @@ def test_get_term_ancestors_with_distances(ontology_parser):
         "CL:0000004": 0,
     }
     assert ontology_parser.get_term_ancestors_with_distances("unknown", include_self=True) == {}
+    assert ontology_parser.get_term_ancestors_with_distances("AfPO:0000000") == {"HANCESTRO:0000000": 1}
+    assert ontology_parser.get_term_ancestors_with_distances("HANCESTRO:0000001") == {
+        "HANCESTRO:0000000": 2,
+        "AfPO:0000000": 1,
+    }
 
 
 def map_term_ancestors_with_distances(ontology_parser):
@@ -137,6 +208,10 @@ def map_term_ancestors_with_distances(ontology_parser):
         "CL:0000000": {"CL:0000000": 0},
         "CL:0000004": {"CL:0000000": 2, "CL:0000001": 1, "CL:0000002": 1, "CL:0000004": 0},
         "unknown": {},
+    }
+    assert ontology_parser.map_term_ancestors_with_distances(["AfPO:0000000", "HANCESTRO:0000001"]) == {
+        "AfPO:0000000": {"HANCESTRO:0000000": 1},
+        "HANCESTRO:0000001": {"HANCESTRO:0000000": 2, "AfPO:0000000": 1},
     }
 
 
@@ -153,6 +228,8 @@ def test_get_term_descendants(ontology_parser):
     assert ontology_parser.get_term_descendants("CL:0000004") == []
     assert ontology_parser.get_term_descendants("CL:0000004", include_self=True) == ["CL:0000004"]
     assert ontology_parser.get_term_descendants("na") == []
+    assert ontology_parser.get_term_descendants("AfPO:0000000") == ["HANCESTRO:0000001"]
+    assert ontology_parser.get_term_descendants("HANCESTRO:0000000") == ["AfPO:0000000", "HANCESTRO:0000001"]
 
 
 def test_map_term_descendants(ontology_parser):
@@ -182,16 +259,23 @@ def test_map_term_descendants(ontology_parser):
         "CL:0000004": ["CL:0000004"],
         "unknown": [],
     }
+    assert ontology_parser.map_term_descendants(["AfPO:0000000", "HANCESTRO:0000000"]) == {
+        "AfPO:0000000": ["HANCESTRO:0000001"],
+        "HANCESTRO:0000000": ["AfPO:0000000", "HANCESTRO:0000001"],
+    }
 
 
 def test_is_term_deprecated(ontology_parser):
     assert ontology_parser.is_term_deprecated("CL:0000003")
     assert not ontology_parser.is_term_deprecated("CL:0000004")
+    assert not ontology_parser.is_term_deprecated("AfPO:0000000")
 
 
 def test_get_term_replacement(ontology_parser):
     assert ontology_parser.get_term_replacement("CL:0000003") == "CL:0000004"
     assert ontology_parser.get_term_replacement("CL:0000004") is None
+    assert ontology_parser.get_term_replacement("HANCESTRO:0000000") is None
+    assert ontology_parser.get_term_replacement("AfPO:0000000") == "AfPO:0000001"
 
 
 def test_get_term_metadata(ontology_parser):
@@ -205,16 +289,30 @@ def test_get_term_metadata(ontology_parser):
         "term_tracker": None,
         "consider": ["CL:0000004"],
     }
+    assert ontology_parser.get_term_metadata("AfPO:0000000") == {
+        "comments": ["this is an AfPO term imported into HANCESTRO"],
+        "term_tracker": "http://example.com/issue/AfPO/1234",
+        "consider": None,
+    }
+    assert ontology_parser.get_term_metadata("HANCESTRO:0000000") == {
+        "comments": ["this is an HANCESTRO term, not imported"],
+        "term_tracker": "http://example.com/issue/HANCESTRO/1234",
+        "consider": None,
+    }
 
 
 def test_get_term_label(ontology_parser):
     assert ontology_parser.get_term_label("CL:0000004") == "cell BC"
+    assert ontology_parser.get_term_label("AfPO:0000000") == "specialized ancestry type"
+    assert ontology_parser.get_term_label("HANCESTRO:0000000") == "root ancestry type"
 
 
 def test_map_term_labels(ontology_parser):
-    assert ontology_parser.map_term_labels(["CL:0000000", "CL:0000004", "unknown", "na"]) == {
+    assert ontology_parser.map_term_labels(["CL:0000000", "CL:0000004", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]) == {
         "CL:0000000": "cell A",
         "CL:0000004": "cell BC",
+        "AfPO:0000000": "specialized ancestry type",
+        "HANCESTRO:0000000": "root ancestry type",
         "unknown": "unknown",
         "na": "na",
     }
@@ -222,12 +320,19 @@ def test_map_term_labels(ontology_parser):
 
 def test_get_term_description(ontology_parser):
     assert ontology_parser.get_term_description("CL:0000000") == "This is cell A."
+    assert ontology_parser.get_term_description("CL:0000004") is None
+    assert ontology_parser.get_term_description("HANCESTRO:0000000") == "This is a root ancestry type."
+    assert ontology_parser.get_term_description("AfPO:0000000") == "This is a specialized ancestry type."
 
 
 def test_map_term_description(ontology_parser):
-    assert ontology_parser.map_term_descriptions(["CL:0000000", "CL:0000004", "unknown", "na"]) == {
+    assert ontology_parser.map_term_descriptions(
+        ["CL:0000000", "CL:0000004", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]
+    ) == {
         "CL:0000000": "This is cell A.",
         "CL:0000004": None,
+        "AfPO:0000000": "This is a specialized ancestry type.",
+        "HANCESTRO:0000000": "This is a root ancestry type.",
         "unknown": "unknown",
         "na": "na",
     }
@@ -235,12 +340,16 @@ def test_map_term_description(ontology_parser):
 
 def test_get_term_synonyms(ontology_parser):
     assert ontology_parser.get_term_synonyms("CL:0000001") == ["cell Beta", "cell Bravo"]
+    assert ontology_parser.get_term_synonyms("AfPO:0000000") == ["specialized ancestry synonym"]
+    assert ontology_parser.get_term_synonyms("HANCESTRO:0000000") == ["root ancestry synonym"]
 
 
 def test_map_term_synonyms(ontology_parser):
-    assert ontology_parser.map_term_synonyms(["CL:0000000", "CL:0000001", "unknown", "na"]) == {
+    assert ontology_parser.map_term_synonyms(["CL:0000000", "CL:0000001", "AfPO:0000000", "HANCESTRO:0000000", "unknown", "na"]) == {
         "CL:0000000": [],
         "CL:0000001": ["cell Beta", "cell Bravo"],
+        "AfPO:0000000": ["specialized ancestry synonym"],
+        "HANCESTRO:0000000": ["root ancestry synonym"],
         "unknown": [],
         "na": [],
     }
@@ -319,7 +428,8 @@ def test_get_distance_between_terms(ontology_parser):
 
 @pytest.mark.parametrize(
     "term_id,expected",
-    [("CL:0000005", ["CL:0000001", "CL:0000002"]), ("CL:0000002", ["CL:0000000"]), ("CL:0000000", []), ("unknown", [])],
+    [("CL:0000005", ["CL:0000001", "CL:0000002"]), ("CL:0000002", ["CL:0000000"]), ("CL:0000000", []), ("unknown", []),
+     ("AfPO:0000000", ["HANCESTRO:0000000"]), ("HANCESTRO:0000001", ["AfPO:0000000"])],
 )
 def test_get_term_parents(ontology_parser, term_id, expected):
     assert ontology_parser.get_term_parents(term_id) == expected
@@ -327,7 +437,8 @@ def test_get_term_parents(ontology_parser, term_id, expected):
 
 @pytest.mark.parametrize(
     "term_id,expected",
-    [("CL:0000000", ["CL:0000001", "CL:0000002", "CL:0000003"]), ("CL:0000005", []), ("unknown", [])],
+    [("CL:0000000", ["CL:0000001", "CL:0000002", "CL:0000003"]), ("CL:0000005", []), ("unknown", []),
+     ("AfPO:0000000", ["HANCESTRO:0000001"]), ("HANCESTRO:0000000", ["AfPO:0000000"])],
 )
 def test_get_term_children(ontology_parser, term_id, expected):
     assert ontology_parser.get_term_children(term_id) == expected
@@ -373,6 +484,20 @@ def test_get_term_graph(ontology_parser):
     }
 
 
+def test_get_term_graph__imported_ontology(ontology_parser):
+    graph = ontology_parser.get_term_graph("AfPO:0000000")
+    assert graph.to_dict() == {
+        "term_id": "AfPO:0000000",
+        "name": "specialized ancestry type",
+        "children": [{"term_id": "HANCESTRO:0000001", "name": "root ontology descendant of specialized ancestry type", "children": []}],
+    }
+
+    assert graph.term_counter == {
+        "AfPO:0000000": 1,
+        "HANCESTRO:0000001": 1,
+    }
+
+
 def test_get_term_label_to_id_map(ontology_parser):
     term_label_to_id_map_expected = {
         "cell A": "CL:0000000",
@@ -389,9 +514,27 @@ def test_get_term_label_to_id_map(ontology_parser):
     assert ontology_parser.term_label_to_id_map["CL"] == term_label_to_id_map_expected
 
 
-def test_get_term_id_by_label(ontology_parser):
-    assert ontology_parser.get_term_id_by_label("cell A", "CL") == "CL:0000000"
-    assert ontology_parser.get_term_id_by_label("cell Z", "CL") is None
+@pytest.mark.parametrize("ontology_name", ["AfPO", "HANCESTRO"])
+def test_get_term_label_to_id_map__imported_ontology(ontology_parser, ontology_name):
+    term_label_to_id_map_expected = {
+        "root ancestry type": "HANCESTRO:0000000",
+        "specialized ancestry type": "AfPO:0000000",
+        "root ontology descendant of specialized ancestry type": "HANCESTRO:0000001",
+    }
+    assert ontology_parser.get_term_label_to_id_map(ontology_name) == term_label_to_id_map_expected
+
+
+@pytest.mark.parametrize(
+    "label,ontology_name,expected",
+    [
+        ("cell A", "CL", "CL:0000000"),
+        ("cell Z", "CL", None),
+        ("root ancestry type", "HANCESTRO", "HANCESTRO:0000000"),
+        ("specialized ancestry type", "AfPO", "AfPO:0000000"),
+    ],
+)
+def test_get_term_id_by_label(ontology_parser, label, ontology_name, expected):
+    assert ontology_parser.get_term_id_by_label(label, ontology_name) == expected
 
 
 def test_get_term_id_by_label__unsupported_ontology_name(ontology_parser):

--- a/api/python/tests/test_supported_versions.py
+++ b/api/python/tests/test_supported_versions.py
@@ -13,6 +13,7 @@ from cellxgene_ontology_guide.supported_versions import (
 
 MODULE_PATH = "cellxgene_ontology_guide.supported_versions"
 
+
 @pytest.fixture
 def ontology_info_content():
     return {
@@ -23,7 +24,7 @@ def ontology_info_content():
                     "version": "v2024-01-01",
                     "source": "http://example.com",
                     "filename": "hancestro.owl",
-                    "additional_ontologies": ["FOO", "OOF"]
+                    "additional_ontologies": ["FOO", "OOF"],
                 },
             }
         }

--- a/api/python/tests/test_supported_versions.py
+++ b/api/python/tests/test_supported_versions.py
@@ -13,14 +13,26 @@ from cellxgene_ontology_guide.supported_versions import (
 
 MODULE_PATH = "cellxgene_ontology_guide.supported_versions"
 
-
 @pytest.fixture
-def initialized_CXGSchemaInfo(mock_load_supported_versions):
-    mock_load_supported_versions.return_value = {
+def ontology_info_content():
+    return {
         "5.0.0": {
-            "ontologies": {"CL": {"version": "v2024-01-01", "source": "http://example.com", "filename": "cl.owl"}}
+            "ontologies": {
+                "CL": {"version": "v2024-01-01", "source": "http://example.com", "filename": "cl.owl"},
+                "HANCESTRO": {
+                    "version": "v2024-01-01",
+                    "source": "http://example.com",
+                    "filename": "hancestro.owl",
+                    "additional_ontologies": ["FOO", "OOF"]
+                },
+            }
         }
     }
+
+
+@pytest.fixture
+def initialized_CXGSchemaInfo(mock_load_supported_versions, ontology_info_content):
+    mock_load_supported_versions.return_value = ontology_info_content
     return CXGSchema()
 
 
@@ -77,12 +89,10 @@ def test_coerce_version(version, expected):
 
 
 class TestCXGSchema:
-    def test__init__defaults(self, mock_load_supported_versions):
-        support_versions = {"5.0.0": {"ontologies": {}}, "0.0.1": {"ontologies": {}}}
-        mock_load_supported_versions.return_value = support_versions
-        cxgs = CXGSchema()
-        assert cxgs.version == "5.0.0"
-        assert cxgs.supported_ontologies == support_versions["5.0.0"]["ontologies"]
+    def test__init__defaults(self, ontology_info_content, initialized_CXGSchemaInfo):
+        assert initialized_CXGSchemaInfo.version == "5.0.0"
+        assert initialized_CXGSchemaInfo.supported_ontologies == ontology_info_content["5.0.0"]["ontologies"]
+        assert initialized_CXGSchemaInfo.imported_ontologies == {"FOO": "HANCESTRO", "OOF": "HANCESTRO"}
 
     @pytest.mark.parametrize("version", ["v0.0.1", "0.0.1"])
     def test__init__specific_version(self, version, mock_load_supported_versions):

--- a/asset-schemas/ontology_info_schema.json
+++ b/asset-schemas/ontology_info_schema.json
@@ -14,35 +14,12 @@
         },
         "ontologies": {
           "type": "object",
-          "properties": {
-            "CL": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "EFO": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "HANCESTRO": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "HsapDv": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "MONDO": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "MmusDv": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "NCBITaxon": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "UBERON": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "PATO": {
+          "patternProperties": {
+            "^[A-Za-z0-9]+$": {
               "$ref": "#/definitions/ontologyEntry"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/tools/ontology-builder/src/validate_json_schemas.py
+++ b/tools/ontology-builder/src/validate_json_schemas.py
@@ -77,7 +77,7 @@ def verify_json(schema_file_name: str, json_file_name: str, registry: Registry) 
 
 
 def validate_unique_ontologies(data):
-    """"
+    """ "
     Custom validation logic to check that all ontologies (including additional_ontologies) defined in ontology_info
     are unique across entries
     """
@@ -87,8 +87,10 @@ def validate_unique_ontologies(data):
             all_ontologies.append(ontology)
             all_ontologies.extend(ontology_info.get("additional_ontologies", []))
         if len(all_ontologies) != len(set(all_ontologies)):
-            logger.error("Ontology entries must be unique across all ontology entries, including "
-                         f"additional_ontologies. Duplicates found in definition for {schema_version}")
+            logger.error(
+                "Ontology entries must be unique across all ontology entries, including "
+                f"additional_ontologies. Duplicates found in definition for {schema_version}"
+            )
             raise ValueError
 
 

--- a/tools/ontology-builder/src/validate_json_schemas.py
+++ b/tools/ontology-builder/src/validate_json_schemas.py
@@ -76,8 +76,8 @@ def verify_json(schema_file_name: str, json_file_name: str, registry: Registry) 
     return True
 
 
-def validate_unique_ontologies(data):
-    """ "
+def validate_unique_ontologies(data) -> None:
+    """
     Custom validation logic to check that all ontologies (including additional_ontologies) defined in ontology_info
     are unique across entries
     """

--- a/tools/ontology-builder/src/validate_json_schemas.py
+++ b/tools/ontology-builder/src/validate_json_schemas.py
@@ -76,7 +76,7 @@ def verify_json(schema_file_name: str, json_file_name: str, registry: Registry) 
     return True
 
 
-def validate_unique_ontologies(data) -> None:
+def validate_unique_ontologies(data: dict) -> None:
     """
     Custom validation logic to check that all ontologies (including additional_ontologies) defined in ontology_info
     are unique across entries

--- a/tools/ontology-builder/src/validate_json_schemas.py
+++ b/tools/ontology-builder/src/validate_json_schemas.py
@@ -67,10 +67,29 @@ def verify_json(schema_file_name: str, json_file_name: str, registry: Registry) 
 
     try:
         validate(instance=data, schema=schema, registry=registry)
+        # custom logic for ontology_info definition
+        if "ontology_info" in schema_file_name:
+            validate_unique_ontologies(data)
     except Exception:
         logger.exception(f"Error validating {json_file_name} against {schema_file_name}")
         return False
     return True
+
+
+def validate_unique_ontologies(data):
+    """"
+    Custom validation logic to check that all ontologies (including additional_ontologies) defined in ontology_info
+    are unique across entries
+    """
+    for schema_version, version_info in data.items():
+        all_ontologies = []
+        for ontology, ontology_info in version_info["ontologies"].items():
+            all_ontologies.append(ontology)
+            all_ontologies.extend(ontology_info.get("additional_ontologies", []))
+        if len(all_ontologies) != len(set(all_ontologies)):
+            logger.error("Ontology entries must be unique across all ontology entries, including "
+                         f"additional_ontologies. Duplicates found in definition for {schema_version}")
+            raise ValueError
 
 
 def main(path: str = env.ONTOLOGY_ASSETS_DIR) -> None:

--- a/tools/ontology-builder/src/validate_json_schemas.py
+++ b/tools/ontology-builder/src/validate_json_schemas.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os.path
 import sys
-from typing import Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 import env
 from jsonschema import validate
@@ -76,7 +76,7 @@ def verify_json(schema_file_name: str, json_file_name: str, registry: Registry) 
     return True
 
 
-def validate_unique_ontologies(data: dict) -> None:
+def validate_unique_ontologies(data: Dict[str, Any]) -> None:
     """
     Custom validation logic to check that all ontologies (including additional_ontologies) defined in ontology_info
     are unique across entries


### PR DESCRIPTION
## Reason for Change

- Continuation of https://github.com/chanzuckerberg/cellxgene-ontology-guide/issues/223 + experimental fruit fly and zebrafish dataset validation work

## Changes

- define an instance attribute "imported_ontologies" in CXGScehma, a Dict[str, str] mapping all "additional_ontologies" defined in "ontology_info.json" to the source ontology it is imported in
- in OntologyParser, when querying for a given ontology prefix, determine if the prefix belongs directly to a supported ontology or if it belongs to an "additional_ontology" imported into a supported ontology. If it belongs to an imported ontology, use CXGScehma.imported_ontologies to find the source ontology it should query for that term (i.e. if a term ID is from an ontology that is an "addtitional_ontology" of ontology A, query ontology A metadata)
      - extracted this logic into helper function "_get_supported_ontology_name", which is called by _parse_ontology_name, which is used by all queries in OntologyParser for input validation.

## Testing steps

- unit tests + local build
- added a test case for cross-ontology terms in the same ontology to all ontologyParser function tests

## Notes for Reviewer
