### PR TITLE
feat: process ontology bridge terms

### DIFF
--- a/asset-schemas/all_ontology_schema.json
+++ b/asset-schemas/all_ontology_schema.json
@@ -31,6 +31,16 @@
           "type": "integer"
         }
       },
+      "bridge_terms": {
+        "type": "object",
+        "description": "Map of bridge terms that connect this ontology term to other ontologies.",
+        "patternProperties": {
+          "^[A-Za-z0-9]+$": {
+            "$ref": "ontology_term_id_schema.json#/definitions/supported_term_id"
+          }
+        },
+        "additionalProperties": false
+      },
       "comments": {
         "type": "array",
         "items": {

--- a/asset-schemas/ontology_info_schema.json
+++ b/asset-schemas/ontology_info_schema.json
@@ -17,15 +17,6 @@
           "patternProperties": {
             "^[A-Za-z0-9]+$": {
               "$ref": "#/definitions/ontologyEntry"
-            },
-            "FBbt": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "FBdv": {
-              "$ref": "#/definitions/ontologyEntry"
-            },
-            "ZFA": {
-              "$ref": "#/definitions/ontologyEntry"
             }
           },
           "additionalProperties": false
@@ -60,15 +51,20 @@
             "type": "string"
           },
           "description": "List of additional term id prefixes to extracted from the source ontology file."
+        },
+        "bridges": {
+          "type": "object",
+          "description": "ontology with mapping files from their terms to this ontology entry's terms.",
+          "patternProperties": {
+            "^[A-Za-z0-9]+$": {
+              "type": "string",
+              "format": "uri",
+              "description": "URI to file mapping between the ontology entry and this ontology"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "required": [
-        "version",
-        "source",
-        "filename"
-      ],
-      "additionalProperties": false
+      }
     }
   }
 }
-

--- a/ontology-assets/ontology_info.json
+++ b/ontology-assets/ontology_info.json
@@ -49,7 +49,11 @@
       "FBbt": {
         "version": "v2024-10-17",
         "source": "https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/download",
-        "filename": "fbbt.owl"
+        "filename": "fbbt.owl",
+        "bridges": {
+          "CL": "https://github.com/obophenotype/uberon/raw/refs/heads/master/src/ontology/bridge/cl-bridge-to-fbbt.owl",
+          "UBERON": "https://github.com/obophenotype/uberon/raw/refs/heads/master/src/ontology/bridge/uberon-bridge-to-fbbt.owl"
+        }
       },
       "FBdv": {
         "version": "v2024-10-17",
@@ -62,7 +66,11 @@
         "filename": "zfa.owl",
         "additional_ontologies": [
           "ZFS"
-        ]
+        ],
+        "bridges": {
+          "CL": "https://github.com/obophenotype/uberon/raw/refs/heads/master/src/ontology/bridge/cl-bridge-to-zfa.owl",
+          "UBERON": "https://github.com/obophenotype/uberon/raw/refs/heads/master/src/ontology/bridge/cl-bridge-to-zfa.owl"
+        }
       }
     }
   },


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell-curation/issues/1002 and https://github.com/chanzuckerberg/single-cell-curation/issues/1003
- Want to process 

## Changes

- update schemas to support specifying ontology term 'bridge' files that map cross-ontology equivalent terms 
- update ontology asset builder to download these bridge files
- IN-PROGRESS: implementing function to extract bridge terms from the bridge files

## Testing steps

- Either list QA steps or reasoning you feel QA is unnecessary
- Describe how you made sure to know that your changes worked. Should allow someone else to go verify your code without in depth knowledge.

## Notes for Reviewer
- TODO: parse the bridge terms from the bridge files, and append to ZFA + FBbt ontology metadata files
- TODO: API support for getting bridge terms given an ontology term ID, where applicable
- TODO: leverage new functions in cellxgene-schema to map organism_cell_type and organism_tissue terms to CL and UBERON terms respectively for experimental organisms
