### PR TITLE
fix: idempotency issue

### DIFF
--- a/api/python/src/cellxgene_ontology_guide/ontology_parser.py
+++ b/api/python/src/cellxgene_ontology_guide/ontology_parser.py
@@ -45,12 +45,12 @@ class OntologyParser:
             raise ValueError(f"{supported_ontology_name} is not a supported ontology, its metadata cannot be fetched.")
 
         if self.term_label_to_id_map[supported_ontology_name]:
-            return self.term_label_to_id_map[supported_ontology_name]
+            return self.term_label_to_id_map[supported_ontology_name].copy()
 
         for term_id, term_metadata in self.cxg_schema.ontology(supported_ontology_name).items():
             self.term_label_to_id_map[supported_ontology_name][term_metadata["label"]] = term_id
 
-        return self.term_label_to_id_map[supported_ontology_name]
+        return self.term_label_to_id_map[supported_ontology_name].copy()
 
     def _parse_ontology_name(self, term_id: str) -> str:
         """
@@ -171,10 +171,8 @@ class OntologyParser:
         if term_id in VALID_NON_ONTOLOGY_TERMS:
             return {}
         ontology_name = self._parse_ontology_name(term_id)
-        ancestors: Dict[str, int] = self.cxg_schema.ontology(ontology_name)[term_id]["ancestors"]
-        if include_self:
-            ancestors[term_id] = 0
-        return ancestors
+        ancestors: Dict[str, int] = self.cxg_schema.ontology(ontology_name)[term_id]["ancestors"].copy()
+        return ancestors | {term_id: 0} if include_self else ancestors
 
     def map_term_ancestors_with_distances(
         self, term_ids: Iterable[str], include_self: bool = False
@@ -626,7 +624,7 @@ class OntologyParser:
         if term_id in VALID_NON_ONTOLOGY_TERMS:
             return []
         ontology_name = self._parse_ontology_name(term_id)
-        synonyms: List[str] = self.cxg_schema.ontology(ontology_name)[term_id].get("synonyms", [])
+        synonyms: List[str] = list(self.cxg_schema.ontology(ontology_name)[term_id].get("synonyms", []))
         return synonyms
 
     def map_term_synonyms(self, term_ids: List[str]) -> Dict[str, List[str]]:


### PR DESCRIPTION
## Reason for Change

- #246
- Issue in ticket stems from using `get_term_ancestors_with_distances` with include_self=True, which is called as part of `get_lowest_common_ancestors`. 
- `get_term_ancestors_with_distances` retrieves a pre-processed dict of ancestors to distances from the given term, and if include_self = True, adds the term itself with a term distance of 0. However, it was doing so on a var referencing the pre-processed dict, rather than on a COPY of dict, causing it to transform the source of truth for ancestor distances.

## Changes

- use a COPY of 'ancestor to distance' mapping when calling get_term_ancestors_with_distances
- found a couple instances of returning mutable source data rather than a copy of the data, and corrected (in `get_term_synonyms` and `get_term_label_to_id_map`)

## Testing steps

- jupyter notebook testing against issue described in ticket
- Not sure if adding a unit test for idempotency makes sense (would be lots of potential combinations to account for), but I can do so for this specific case we caught if we feel like it'll be useful

## Notes for Reviewer
