### PR TITLE
Add python compile cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .coverage*
 /htmlcov/
 /api/python/docs/
+
+# Compiled python files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Reason for Change

Very minor PR. Just noticed that `__pycache__` directories were showing up as untracked when I was playing around with the package, and these are normally included in `.gitignore`s so they don't get committed by mistake.

## Changes

- add some lines to `.gitignore`
