### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
 name: release-please
 jobs:
   release-please:
-    runs-on: [self-hosted, ARM64]
+    runs-on: ARM64
     steps:
       - name: release please
         uses: google-github-actions/release-please-action@v4.1.1


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.