### PR TITLE
chore: trigger new release

### DIFF
--- a/ontology-assets/CHANGELOG.md
+++ b/ontology-assets/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## [1.6.0](https://github.com/chanzuckerberg/cellxgene-ontology-guide/compare/ontology-assets-v1.5.0...ontology-assets-v1.6.0) (2025-06-02)
 
 


### PR DESCRIPTION
`release-please` failed because even though the `1.7.0` release wasn't published to pypi, the release-please artifacts already existed. so we'll need to have the new release be `1.7.1`