### PR TITLE
chore: update release-please action and config schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ARM64
     steps:
       - name: release please
-        uses: google-github-actions/release-please-action@v4.1.1
+        uses: googleapis/release-please-action@v17.1.2
         id: release
         with:
           manifest-file: ".release-please-manifest.json"
@@ -31,36 +31,24 @@ jobs:
     runs-on: [ubuntu-latest]
     needs: release-please
     if: contains(needs.release-please.outputs.paths_released, 'ontology-assets')
-    strategy:
-      matrix:
-        include:
-          - file_name: "ontology_info.json"
-            content_type: "application/json"
-          - file_name: "cell_class_list.json"
-            content_type: "application/json"
-          - file_name: "cell_subclass_list.json"
-            content_type: "application/json"
-          - file_name: "organ_list.json"
-            content_type: "application/json"
-          - file_name: "tissue_general_list.json"
-            content_type: "application/json"
-          - file_name: "system_list.json"
-            content_type: "application/json"
-          - file_name: "uberon_development_stage_list.json"
-            content_type: "application/json"
     steps:
       - name: Checkout ref branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ needs.release-please.outputs.ontology_assets_upload_url }}
-          asset_path: "ontology-assets/${{ matrix.file_name }}"
-          asset_name: ${{ matrix.file_name }}
-          asset_content_type: ${{ matrix.content_type }}
+          files: |
+            ontology-assets/ontology_info.json
+            ontology-assets/cell_class_list.json
+            ontology-assets/cell_subclass_list.json
+            ontology-assets/organ_list.json
+            ontology-assets/tissue_general_list.json
+            ontology-assets/system_list.json
+            ontology-assets/uberon_development_stage_list.json
+          tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "bump-minor-pre-major": true,
   "initial-version": "0.0.1",


### PR DESCRIPTION
This pull request updates the release workflow to use more recent and better-supported GitHub Actions and simplifies the asset upload process. It also adds a schema reference to the release configuration file for improved validation.

**Release workflow improvements:**

* Updated the `release-please` action in `.github/workflows/release.yml` to use the latest maintained version (`googleapis/release-please-action@v17.1.2`) instead of the older one (`google-github-actions/release-please-action@v4.1.1`).
* Replaced the asset upload logic in `.github/workflows/release.yml` by removing the matrix strategy and switching from `actions/upload-release-asset@v1` to `softprops/action-gh-release@v2`, allowing multiple assets to be uploaded in a single step and simplifying the workflow.

**Configuration improvements:**

* Added a `$schema` property to `release-please-config.json` for validation and editor support.