### PR TITLE
feat: remove + character from regex [VC-4536] 

### DIFF
--- a/asset-schemas/ontology_term_id_schema.json
+++ b/asset-schemas/ontology_term_id_schema.json
@@ -8,67 +8,67 @@
     },
     "CVCL_term_id": {
       "type": "string",
-      "pattern": "^CVCL+_[A-Z0-9]+$"
+      "pattern": "^CVCL_[A-Z0-9]+$"
     },
     "CL_term_id": {
       "type": "string",
-      "pattern": "^CL+:[0-9]+$"
+      "pattern": "^CL:[0-9]+$"
     },
     "EFO_term_id": {
       "type": "string",
-      "pattern": "^EFO+:[0-9]+$"
+      "pattern": "^EFO:[0-9]+$"
     },
     "HANCESTRO_term_id": {
       "type": "string",
-      "pattern": "^HANCESTRO+:[0-9]+$"
+      "pattern": "^HANCESTRO:[0-9]+$"
     },
     "HsapDv_term_id": {
       "type": "string",
-      "pattern": "^HsapDv+:[0-9]+$"
+      "pattern": "^HsapDv:[0-9]+$"
     },
     "MmusDv_term_id": {
       "type": "string",
-      "pattern": "^MmusDv+:[0-9]+$"
+      "pattern": "^MmusDv:[0-9]+$"
     },
     "MONDO_term_id": {
       "type": "string",
-      "pattern": "^MONDO+:[0-9]+$"
+      "pattern": "^MONDO:[0-9]+$"
     },
     "NCBITaxon_term_id": {
       "type": "string",
-      "pattern": "^NCBITaxon+:[0-9]+$"
+      "pattern": "^NCBITaxon:[0-9]+$"
     },
     "PATO_term_id": {
       "type": "string",
-      "pattern": "^PATO+:[0-9]+$"
+      "pattern": "^PATO:[0-9]+$"
     },
     "UBERON_term_id": {
       "type": "string",
-      "pattern": "^UBERON+:[0-9]+$"
+      "pattern": "^UBERON:[0-9]+$"
     },
     "FBbt_term_id": {
       "type": "string",
-      "pattern": "^FBbt+:[0-9]+$"
+      "pattern": "^FBbt:[0-9]+$"
     },
     "FBdv_term_id": {
       "type": "string",
-      "pattern": "^FBdv+:[0-9]+$"
+      "pattern": "^FBdv:[0-9]+$"
     },
     "ZFA_term_id": {
       "type": "string",
-      "pattern": "^ZFA+:[0-9]+$"
+      "pattern": "^ZFA:[0-9]+$"
     },
     "ZFS_term_id": {
       "type": "string",
-      "pattern": "^ZFS+:[0-9]+$"
+      "pattern": "^ZFS:[0-9]+$"
     },
     "WBls_term_id": {
       "type": "string",
-      "pattern": "^WBls+:[0-9]+$"
+      "pattern": "^WBls:[0-9]+$"
     },
     "WBbt_term_id": {
       "type": "string",
-      "pattern": "^WBbt+:[0-9]+$"
+      "pattern": "^WBbt:[0-9]+$"
     },
     "supported_term_id": {
       "anyOf": [


### PR DESCRIPTION
Small change to Regex:

the `+` character allows for one to many of the immediately previous capture group (in this case, since no capture group is explicitly stated, it just defaults to the previous character). This was resulting in the regex expression yielding valid for things that our logic dictates to be invalid. For example:

The regex `"^ZFA+:[0-9]+$"` would be valid for the following:
- `ZFA:1234`
- `ZFAAA:1234`
- `ZFAAAAAAAAAAAAAAAAAAAA:1234` 

Where as we should only expect it to be valid for the first one.
The change in this PR simply removes the `+` symbol where relevant
